### PR TITLE
Boca guidebook fix

### DIFF
--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bocadillo.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Bocadillo.xml
@@ -9,19 +9,19 @@
   <GuideEntityEmbed Entity="ShuttleMapBocadillo" Caption=""/>
   </Box>
   [color=#a4885c]Ship Size:[/color] Small
-  
+
   [color=#a4885c]Recommended Crew:[/color] 1-2
-  
-  [color=#a4885c]Power Gen Type:[/color] Plasma
-  
+
+  [color=#a4885c]Power Gen Type:[/color] Uranium
+
   [color=#a4885c]Expeditions:[/color] None
-  
+
   [color=#a4885c]IFF Console:[/color] None
-  
+
   "A tiny food truck perfect for a solo chef or a small crew."
-  
+
   # Tips on running NC Bocadillo shuttles
   - Optimal Target Power (kW) for S.U.P.E.R.P.A.C.M.A.N. generator unit is 16 [bold]kW[/bold]. If you've added additional machines, check APC unit to see shuttle's power draw and adjust generator Target Power accordingly. For more general info on power grid see guidebook article [textlink="Power" link="Power"].
   - For basics of shuttle piloting see [textlink="Piloting" link="Piloting"].
-  
+
 </Document>


### PR DESCRIPTION
Sets it to Uranium in the guidebook to match reality.