### PR TITLE
Shh im trying to be subtle

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -15,6 +15,7 @@ namespace Content.Client.Input
             common.AddFunction(ContentKeyFunctions.FocusChat);
             common.AddFunction(ContentKeyFunctions.FocusLocalChat);
             common.AddFunction(ContentKeyFunctions.FocusEmote);
+            common.AddFunction(ContentKeyFunctions.FocusSubtle);
             common.AddFunction(ContentKeyFunctions.FocusWhisperChat);
             common.AddFunction(ContentKeyFunctions.FocusRadio);
             common.AddFunction(ContentKeyFunctions.FocusLOOC);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -228,6 +228,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.FocusChat);
             AddButton(ContentKeyFunctions.FocusLocalChat);
             AddButton(ContentKeyFunctions.FocusEmote);
+            AddButton(ContentKeyFunctions.FocusSubtle);
             AddButton(ContentKeyFunctions.FocusWhisperChat);
             AddButton(ContentKeyFunctions.FocusRadio);
             AddButton(ContentKeyFunctions.FocusLOOC);

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -203,6 +203,9 @@ public sealed partial class ChatUIController : UIController
         _input.SetInputCommand(ContentKeyFunctions.FocusEmote,
             InputCmdHandler.FromDelegate(_ => FocusChannel(ChatSelectChannel.Emotes)));
 
+        _input.SetInputCommand(ContentKeyFunctions.FocusSubtle,
+            InputCmdHandler.FromDelegate(_ => FocusChannel(ChatSelectChannel.Subtle)));
+
         _input.SetInputCommand(ContentKeyFunctions.FocusWhisperChat,
             InputCmdHandler.FromDelegate(_ => FocusChannel(ChatSelectChannel.Whisper)));
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public const int LOOCRange = 15; // how far LOOC goes in world units
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    public const int SubtleLOOCRange = 3; // how far Subtle LOOC goes in world units
+    public const int SubtleLOOCRange = 2; // how far Subtle LOOC goes in world units
     public const int WhisperClearRange = 2; // how far whisper goes while still being understandable, in world units
     public const int WhisperMuffledRange = 5; // how far whisper goes at all, in world units
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
@@ -820,7 +820,18 @@ public sealed partial class ChatSystem : SharedChatSystem
             ("entityName", name),
             ("message", FormattedMessage.EscapeText(message)));
 
-        SendInVoiceRange(ChatChannel.LOOC, message, wrappedMessage, source, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, player.UserId);
+        SendInVoiceRange(
+            ChatChannel.LOOC,
+            message,
+            wrappedMessage,
+            source,
+            hideChat
+                ? ChatTransmitRange.HideChat
+                : ChatTransmitRange.Normal,
+            player.UserId,
+            voiceRange: LOOCRange, // COYOTESTATION ADD - LOOC goes further
+            blockedByOcclusion: !LOOCGoesThroughWalls, // COYOTESTATION ADD - some things dont do thru walls
+            ensmallenedByOcclusion: false); // COYOTESTATION ADD - LOOC dont get ensmallened by occlusion
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"LOOC from {player:Player}: {message}");
     }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -238,13 +238,25 @@ public sealed partial class ChatSystem : SharedChatSystem
             message = message[1..];
         }
 
-        bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
+        var shouldCapitalize = desiredType switch
+        {
+            // Subtle messages are not capitalized.
+            InGameICChatType.Emote => false,
+            InGameICChatType.Subtle => false,
+            _ => true,
+        };
         bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
         // Capitalizing the word I only happens in English, so we check language here
         bool shouldCapitalizeTheWordI = (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")
             || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en");
 
-        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI);
+        message = SanitizeInGameICMessage(
+            source,
+            message,
+            out var emoteStr,
+            shouldCapitalize,
+            shouldPunctuate,
+            shouldCapitalizeTheWordI);
 
         var entityName = Identity.Name(source, EntityManager);
         if (string.IsNullOrEmpty(entityName))
@@ -257,9 +269,16 @@ public sealed partial class ChatSystem : SharedChatSystem
         var nameColorString = nameHashColorAdjusted.ToHex();
 
         // Was there an emote in the message? If so, send it.
-        if (emoteStr != message && emoteStr != null)
+        if (emoteStr != message
+            && emoteStr != null)
         {
-            SendEntityEmote(source, emoteStr, range, nameOverride, ignoreActionBlocker, chatColor: nameColorString);
+            SendEntityEmote(
+                source,
+                emoteStr,
+                range,
+                nameOverride,
+                ignoreActionBlocker,
+                chatColor: nameColorString);
         }
 
         // This can happen if the entire string is sanitized out.
@@ -269,9 +288,21 @@ public sealed partial class ChatSystem : SharedChatSystem
         // This message may have a radio prefix, and should then be whispered to the resolved radio channel
         if (checkRadioPrefix)
         {
-            if (TryProccessRadioMessage(source, message, out var modMessage, out var channel))
+            if (TryProccessRadioMessage(
+                    source,
+                    message,
+                    out var modMessage,
+                    out var channel))
             {
-                SendEntityWhisper(source, modMessage, range, channel, nameOverride, hideLog, ignoreActionBlocker, chatColor: nameColorString);
+                SendEntityWhisper(
+                    source,
+                    modMessage,
+                    range,
+                    channel,
+                    nameOverride,
+                    hideLog,
+                    ignoreActionBlocker,
+                    chatColor: nameColorString);
                 return;
             }
         }
@@ -280,17 +311,46 @@ public sealed partial class ChatSystem : SharedChatSystem
         switch (desiredType)
         {
             case InGameICChatType.Speak:
-                SendEntitySpeak(source, message, range, nameOverride, hideLog, ignoreActionBlocker, chatColor: nameColorString);
+                SendEntitySpeak(
+                    source,
+                    message,
+                    range,
+                    nameOverride,
+                    hideLog,
+                    ignoreActionBlocker,
+                    chatColor: nameColorString);
                 break;
             case InGameICChatType.Whisper:
-                SendEntityWhisper(source, message, range, null, nameOverride, hideLog, ignoreActionBlocker, chatColor: nameColorString);
+                SendEntityWhisper(
+                    source,
+                    message,
+                    range,
+                    null,
+                    nameOverride,
+                    hideLog,
+                    ignoreActionBlocker,
+                    chatColor: nameColorString);
                 break;
             case InGameICChatType.Emote:
-                SendEntityEmote(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker, chatColor: nameColorString);
+                SendEntityEmote(
+                    source,
+                    message,
+                    range,
+                    nameOverride,
+                    hideLog: hideLog,
+                    ignoreActionBlocker: ignoreActionBlocker,
+                    chatColor: nameColorString);
                 break;
             case InGameICChatType.Subtle:
-                SendEntitySubtle(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker, chatColor: nameColorString);
-                break;
+                SendEntitySubtle(
+                    source,
+                    message,
+                    range,
+                    nameOverride,
+                    hideLog: hideLog,
+                    ignoreActionBlocker: ignoreActionBlocker,
+                    chatColor: nameColorString);
+                break; // i chop them so my PRs look bigger >w<;
         }
     }
 
@@ -327,8 +387,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             sendType = InGameOOCChatType.Dead;
 
         // If crit player LOOC is disabled, don't send the message at all.
-        if (!_critLoocEnabled && _mobStateSystem.IsCritical(source))
-            return;
+        // if (!_critLoocEnabled && _mobStateSystem.IsCritical(source))
+        //     return;
 
         switch (sendType)
         {
@@ -717,14 +777,13 @@ public sealed partial class ChatSystem : SharedChatSystem
         var wrappedMessage = Loc.GetString("chat-manager-entity-subtle-wrap-message",
             ("entityName", name),
             ("entity", ent),
-            ("message", FormattedMessage.RemoveMarkup(action)),
+            ("message", FormattedMessage.RemoveMarkupOrThrow(action)),
             ("chatColor", chatColor ?? Color.White.ToHex())); // COYOTESTATION ADD - makes the your name color right
         var numHeareded = 0;
         foreach (var (session, data) in GetRecipients(
                      source,
                      SubtleRange,
-                     blockedByOcclusion: !SubtleGoesThroughWalls
-                     ))
+                     blockedByOcclusion: !SubtleGoesThroughWalls))
         {
             if (session.AttachedEntity is not { Valid: true } listener)
                 continue;

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction FocusChat = "FocusChatInputWindow";
         public static readonly BoundKeyFunction FocusLocalChat = "FocusLocalChatWindow";
         public static readonly BoundKeyFunction FocusEmote = "FocusEmote";
+        public static readonly BoundKeyFunction FocusSubtle = "FocusSubtle";
         public static readonly BoundKeyFunction FocusWhisperChat = "FocusWhisperChatWindow";
         public static readonly BoundKeyFunction FocusRadio = "FocusRadioWindow";
         public static readonly BoundKeyFunction FocusLOOC = "FocusLOOCWindow";

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -29,14 +29,14 @@ chat-manager-entity-whisper-wrap-message = [font size=11][italic][BubbleHeader][
 chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic][BubbleHeader][color={$chatColor}]Someone[/color][/BubbleHeader] whispers, "[BubbleContent]{$message}[/BubbleContent]"[/italic][/font]
 
 # THE() is not used here because the entity and its name can technically be disconnected if a nameOverride is passed...
-chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
-    *[false] The [color={$chatColor}]{$entityName}[/color] {$message}[/italic]
-     [true] [color={$chatColor}]{CAPITALIZE($entityName)}[/color] {$message}[/italic]
+chat-manager-entity-me-wrap-message = { PROPER($entity) ->
+    *[false] The [color={$chatColor}]{$entityName}[/color] {$message}
+     [true] [color={$chatColor}]{CAPITALIZE($entityName)}[/color] {$message}
     }
 
-chat-manager-entity-subtle-wrap-message = [italic]{ PROPER($entity) ->
-    *[false] the [color={$chatColor}]{$entityName}[/color] subtly {$message}[/italic]
-     [true] [color={$chatColor}]{$entityName}[/color] subtly {$message}[/italic]
+chat-manager-entity-subtle-wrap-message = { PROPER($entity) ->
+    *[false] [font size=11][italic]the [color={$chatColor}]{$entityName}[/color] {$message}[/italic][/font]
+     [true] [font size=11][italic][color={$chatColor}]{$entityName}[/color] {$message}[/italic][/font]
     }
 
 chat-manager-entity-looc-wrap-message = LOOC: [bold]{$entityName}:[/bold] {$message}

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -116,6 +116,9 @@ binds:
 - function: FocusRadioWindow
   type: State
   key: SemiColon
+- function: FocusSubtle
+  type: State
+  key: Minus
 - function: FocusLOOCWindow
   type: State
   mod1: Shift


### PR DESCRIPTION
This pull request introduces a new "Subtle" chat functionality across the codebase, including its input handling, configuration, and server-side logic. It also includes several refactors for improved readability and consistency in chat-related methods. Below are the most important changes grouped by theme:

### Subtle Chat Feature Integration:

* Added a new keybind `FocusSubtle` for activating the "Subtle" chat channel and integrated it into input handling (`Content.Shared/Input/ContentKeyFunctions.cs`, `Content.Client/Input/ContentContexts.cs`, `Resources/keybinds.yml`). [[1]](diffhunk://#diff-d0bb216ec2e6e7d21fadbff582114775d00c898790beb706ac5328d38e1c938fR17) [[2]](diffhunk://#diff-16db0379674525956db1b21a6e76ace9924f4e6848f82e84334f401c9f4777b0R18) [[3]](diffhunk://#diff-52755a84aea77581d755598f6e174d7eaf63d24eac077598652f98644ee4db89R119-R121)
* Updated the chat UI controller to handle the new "Subtle" chat channel, mapping the input to the appropriate command (`Content.Client/UserInterface/Systems/Chat/ChatUIController.cs`).
* Adjusted the `SubtleLOOCRange` constant to reduce its range from 3 to 2 world units (`Content.Server/Chat/Systems/ChatSystem.cs`).

### Chat System Enhancements:

* Modified `TrySendInGameICMessage` to ensure "Subtle" messages are not capitalized and adjusted message sanitization and formatting logic (`Content.Server/Chat/Systems/ChatSystem.cs`). [[1]](diffhunk://#diff-0eb5df8d137cd4711bbde50acf9057a12a5c1efbb03badecabbb635af4d9fcb5L241-R259) [[2]](diffhunk://#diff-0eb5df8d137cd4711bbde50acf9057a12a5c1efbb03badecabbb635af4d9fcb5L720-R786)
* Updated the `SendEntitySubtle` method to improve message wrapping and ensure proper handling of "Subtle" chat messages (`Content.Server/Chat/Systems/ChatSystem.cs`).

### Localization and UI Updates:

* Adjusted the localization strings for "Subtle" chat messages to refine their display formatting (`Resources/Locale/en-US/chat/managers/chat-manager.ftl`).

### Code Refactors:

* Refactored several methods in `ChatSystem` to improve readability by reformatting method calls and conditionals (`Content.Server/Chat/Systems/ChatSystem.cs`). [[1]](diffhunk://#diff-0eb5df8d137cd4711bbde50acf9057a12a5c1efbb03badecabbb635af4d9fcb5L260-R281) [[2]](diffhunk://#diff-0eb5df8d137cd4711bbde50acf9057a12a5c1efbb03badecabbb635af4d9fcb5L272-R305) [[3]](diffhunk://#diff-0eb5df8d137cd4711bbde50acf9057a12a5c1efbb03badecabbb635af4d9fcb5L283-R353)

These changes collectively implement the "Subtle" chat channel while improving code clarity and maintaining consistency across the chat system.<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

great thanks so anyway this PR does this:
- you can LOOC in crit
- subtles dont get capitalized
- emotes arent italicized
- adds a subtle hotkey (can keybind it, defaults to - though i dunno if it does that for everyone)
- removes the subtly part
