### PR TITLE
adjusts tradecrates some more

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Specific/TradingCrates/crates.yml
@@ -46,7 +46,7 @@
     valueAtDestination: 2000 # 2500 original
     valueElsewhere: 1500 # 1500 original
     expressDeliveryDuration: 3600 # 1680 (28 minutes) original -> 2700 (45 minutes) -> 3600 (60 minutes)
-    expressOnTimeBonus: 1500 # 1500 original
+    expressOnTimeBonus: 2000 # 1500 original
     expressLatePenalty: 1000 # 1000 original
   - type: Icon
     sprite: _NF/Structures/Storage/Crates/tradelight.rsi


### PR DESCRIPTION
a slightly higher on time bonus means that big loaders won't really be affected, but solos will benefit more. 