### PR TITLE
Buffs the Biogen

### DIFF
--- a/Content.Shared/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Storage.Components;
 using Content.Shared.Materials;
 using Robust.Shared.Physics.Components;
+using Content.Server.Materials;
 using Robust.Shared.Timing;
 using Content.Shared.Examine;   // Frontier
 using Content.Shared.Hands.Components;  // Frontier
@@ -110,9 +111,19 @@ public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
                 if (near == parentUid)
                     continue;
 
+                var  ev = new FeedProduceEvent(near);
+                RaiseLocalEvent(uid, ev, true);
+                if (ev.Handled)
+                    continue;
+
                 if (!_storage.TryInsertMaterialEntity(uid, near, uid, storage))
                     continue;
             }
         }
     }
+}
+public sealed class FeedProduceEvent(EntityUid used) // cool event, dan
+{
+    public bool Handled = false;
+    public EntityUid Used { get; } = used;
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -219,7 +219,8 @@
   - type: MachineBoard
     prototype: Biogenerator
     requirements: # Frontier
-      MatterBin: 2 # Frontier stackRequirements<requirements
+      MatterBin: 1 # Frontier stackRequirements<requirements
+      Manipulator: 1 # Make this damn thing suck less
     tagRequirements:
       GlassBeaker:
         amount: 1

--- a/Resources/Prototypes/_NF/Recipes/Lathes/biogen.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/biogen.yml
@@ -61,7 +61,6 @@
   id: NFBioGenFoodMeat
   result: FoodMeat
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
   completetime: 10
   materials:
     Biomass: 35
@@ -72,7 +71,6 @@
   id: NFBioGenFoodMeatWholeChicken
   result: FoodMeatWholeChicken
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
   completetime: 20
   materials:
     Biomass: 70
@@ -81,7 +79,6 @@
   id: NFBioGenFoodMeatWholePenguin
   result: FoodMeatWholePenguin
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
   completetime: 30
   materials:
     Biomass: 105
@@ -90,7 +87,6 @@
   id: NFBioGenFoodMeatWholeDuck
   result: FoodMeatWholeDuck
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
   completetime: 20
   materials:
     Biomass: 70
@@ -99,19 +95,17 @@
   id: NFBioGenFoodMeatCrab
   result: FoodMeatCrab
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
   completetime: 10
   materials:
     Biomass: 25 #Crab is a more specific recipe, also crabs are smaller so I pressume the cut of crab meat is easier to make than a full steak
-    
+
 - type: latheRecipe
   id: NFBioGenFoodMeatBacon
   result: FoodMeatBacon
   parent: BioGenFoodRecipe
-  applyMaterialDiscount: false
   completetime: 10
   materials:
-    Biomass: 35 
+    Biomass: 35
 
 #region Cubes
 


### PR DESCRIPTION
The biogenerator now has a working magnet, and will suck in anything that could be otherwise inserted manually. No more do you have to click it one at a time like youre paying for a sodie machine with a gallon of pennies.

The biogenerator now has a manipulator, which means that its speed can be upgraded. It also uses just one matter bin instead of two, which makes it easier to max out its material use discount. Note that more parts does NOT mean better machine, it just means you need more parts to get to the same level.

Meat now has this discount applied, so you can print out meat for cheaper. Yes this is so you can feed my OC more meat snacks during *those scenes*, thats why I did this, for kink purposes. Have fun!