### PR TITLE
send the imporant stuff to admin chat

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -795,7 +795,7 @@ namespace Content.Server.Administration.Systems
                 if (_playerManager.TryGetSessionByChannel(admin, out var sesh))
                 {
                     _chatManager.ChatMessageToOne(
-                        ChatChannel.Admin,
+                        ChatChannel.AdminChat,
                         superOverrideText,
                         superOverrideText,
                         default,


### PR DESCRIPTION
Bwoinks are sent to admin chat channel, so its easier to soft soft deadmin by just turning off the useless debug info