### PR TITLE
MARKINGS FOR ALL

### DIFF
--- a/Content.Shared/Humanoid/HumanoidAppearanceComponent.cs
+++ b/Content.Shared/Humanoid/HumanoidAppearanceComponent.cs
@@ -69,6 +69,12 @@ public sealed partial class HumanoidAppearanceComponent : Component
     public Dictionary<HumanoidVisualLayers, SlotFlags> HiddenLayers = new();
 
     /// <summary>
+    /// So. When the mob has a custom layer base thing in this slot, it will be hidden.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<HumanoidVisualLayers> HiddenBaseLayers = new();
+
+    /// <summary>
     /// The specific markings that are hidden, whether or not the layer is hidden.
     /// This is so we can just turn off a single marking, or part of a single marking.
     /// (cus underwear, its for underwear, so you can take off your bra and still have your shirt on)

--- a/Content.Shared/Humanoid/HumanoidVisualLayers.cs
+++ b/Content.Shared/Humanoid/HumanoidVisualLayers.cs
@@ -40,6 +40,7 @@ namespace Content.Shared.Humanoid
         RArmExtension, // Frontier: a species-specific extension layer, e.g. for harpy wings
         UndershirtUnderclothes,
         UndershirtOverclothes,
+        Disregard,
     }
 }
 

--- a/Content.Shared/Humanoid/Markings/MarkingCategories.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingCategories.cs
@@ -18,11 +18,48 @@ namespace Content.Shared.Humanoid.Markings
         Arms,
         Legs,
         Tail,
-        Overlay
+        Overlay,
+        BaseChest,
+        BaseHead,
+        BaseLArm,
+        BaseLFoot,
+        BaseLHand,
+        BaseLLeg,
+        BaseRArm,
+        BaseRFoot,
+        BaseRHand,
+        BaseRLeg,
     }
 
     public static class MarkingCategoriesConversion
     {
+        /// <summary>
+        /// Easy cheat cheet for converting BaseLayers to Bodyparts to hide!
+        /// Basically, if I have a marking in THIS category selected, I want to hide the base layer of that body part.
+        /// fucking kill me, dennis.
+        /// </summary>
+        public static bool Category2Layer(
+            MarkingCategories category,
+            out HumanoidVisualLayers baseLayerToHide
+            )
+        {
+            baseLayerToHide = category switch
+            {
+                MarkingCategories.BaseChest => HumanoidVisualLayers.Chest,
+                MarkingCategories.BaseHead => HumanoidVisualLayers.Head,
+                MarkingCategories.BaseLArm => HumanoidVisualLayers.LArm,
+                MarkingCategories.BaseLFoot => HumanoidVisualLayers.LFoot,
+                MarkingCategories.BaseLHand => HumanoidVisualLayers.LHand,
+                MarkingCategories.BaseLLeg => HumanoidVisualLayers.LLeg,
+                MarkingCategories.BaseRArm => HumanoidVisualLayers.RArm,
+                MarkingCategories.BaseRFoot => HumanoidVisualLayers.RFoot,
+                MarkingCategories.BaseRHand => HumanoidVisualLayers.RHand,
+                MarkingCategories.BaseRLeg => HumanoidVisualLayers.RLeg,
+                _ => HumanoidVisualLayers.Disregard, // dont trigger the base layer hiding logic, dennis
+            };
+            return baseLayerToHide != HumanoidVisualLayers.Disregard;
+        }
+
         public static MarkingCategories FromHumanoidVisualLayers(HumanoidVisualLayers layer)
         {
             return layer switch

--- a/Content.Shared/Humanoid/Markings/MarkingManager.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingManager.cs
@@ -326,12 +326,10 @@ namespace Content.Shared.Humanoid.Markings
         {
             IoCManager.Resolve(ref prototypeManager);
             var speciesProto = prototypeManager.Index<SpeciesPrototype>(species);
-            if (
-                !prototypeManager.TryIndex(speciesProto.SpriteSet, out var baseSprites) ||
-                !baseSprites.Sprites.TryGetValue(layer, out var spriteName) ||
-                !prototypeManager.TryIndex(spriteName, out HumanoidSpeciesSpriteLayer? sprite) ||
-                sprite == null ||
-                !sprite.MarkingsMatchSkin
+            if (!prototypeManager.TryIndex(speciesProto.SpriteSet, out var baseSprites)
+                || !baseSprites.Sprites.TryGetValue(layer, out var spriteName)
+                || !prototypeManager.TryIndex(spriteName, out HumanoidSpeciesSpriteLayer? sprite)
+                || !sprite.MarkingsMatchSkin
             )
             {
                 alpha = 1f;
@@ -347,12 +345,10 @@ namespace Content.Shared.Humanoid.Markings
         {
             IoCManager.Resolve(ref prototypeManager);
             var speciesProto = prototypeManager.Index<SpeciesPrototype>(species);
-            if (
-                !prototypeManager.TryIndex(speciesProto.SpriteSet, out HumanoidSpeciesBaseSpritesPrototype? baseSprites) ||
-                !baseSprites.Sprites.TryGetValue(layer, out var spriteName) ||
-                !prototypeManager.TryIndex(spriteName, out HumanoidSpeciesSpriteLayer? sprite) ||
-                sprite == null ||
-                !sprite.ForcedColoring
+            if (!prototypeManager.TryIndex(speciesProto.SpriteSet, out HumanoidSpeciesBaseSpritesPrototype? baseSprites)
+                || !baseSprites.Sprites.TryGetValue(layer, out var spriteName)
+                || !prototypeManager.TryIndex(spriteName, out HumanoidSpeciesSpriteLayer? sprite)
+                || !sprite.ForcedColoring
             )
             {
                 alpha = 1f;

--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -296,28 +296,41 @@ public sealed partial class MarkingSet
     /// <param name="eyeColor">Eye color for marking coloring.</param>
     /// <param name="hairColor">Hair color for marking coloring.</param>
     /// <param name="markingManager">Marking manager.</param>
-    public void EnsureDefault(Color? skinColor = null, Color? eyeColor = null, MarkingManager? markingManager = null)
+    /// <param name="humanoidAppearance">Humanoid appearance component for what markings they have whatever.</param>
+    public void EnsureDefault(
+        Color? skinColor = null,
+        Color? eyeColor = null,
+        MarkingManager? markingManager = null)
     {
         IoCManager.Resolve(ref markingManager);
 
         foreach (var (category, points) in Points)
         {
-            if (points.Points <= 0 || points.DefaultMarkings.Count <= 0)
+            if (points.Points <= 0
+                || points.DefaultMarkings.Count <= 0)
+            {
+                continue;
+            }
+
+            // check if they have ANY markings in this category
+            // and if so, skip this category
+            if (Markings.TryGetValue(category, out var markings)
+                && markings.Count > 0)
             {
                 continue;
             }
 
             var index = 0;
-            while (points.Points > 0 && index < points.DefaultMarkings.Count)
+            while (points.Points > 0
+                   && index < points.DefaultMarkings.Count)
             {
                 if (markingManager.Markings.TryGetValue(points.DefaultMarkings[index], out var prototype))
                 {
                     var colors = MarkingColoring.GetMarkingLayerColors(
-                            prototype,
-                            skinColor,
-                            eyeColor,
-                            this
-                        );
+                        prototype,
+                        skinColor,
+                        eyeColor,
+                        this);
                     var marking = new Marking(points.DefaultMarkings[index], colors);
 
                     AddBack(category, marking);

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -502,7 +502,11 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
         {
             return;
         }
-        humanoid.MarkingSet.EnsureDefault(humanoid.SkinColor, humanoid.EyeColor, _markingManager);
+
+        humanoid.MarkingSet.EnsureDefault(
+            humanoid.SkinColor,
+            humanoid.EyeColor,
+            _markingManager);
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/preferences/ui/markings-picker.ftl
+++ b/Resources/Locale/en-US/preferences/ui/markings-picker.ftl
@@ -28,3 +28,14 @@ markings-category-Arms = Arms
 markings-category-Legs = Legs
 markings-category-Tail = Tail
 markings-category-Overlay = Overlay
+
+markings-category-BaseChest = UnderStructure Chest
+markings-category-BaseHead  = UnderStructure Head
+markings-category-BaseLArm  = UnderStructure Arm (left)
+markings-category-BaseLFoot = UnderStructure Foot (left)
+markings-category-BaseLHand = UnderStructure Hand (left)
+markings-category-BaseLLeg  = UnderStructure Leg (left)
+markings-category-BaseRArm  = UnderStructure Arm (right)
+markings-category-BaseRFoot = UnderStructure Foot (right)
+markings-category-BaseRHand = UnderStructure Hand (right)
+markings-category-BaseRLeg  = UnderStructure Leg (right)

--- a/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/felinid.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Felinid
   name: species-name-felinid
@@ -14,39 +15,80 @@
   id: MobFelinidMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ FelinidTailBasic ]
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ FelinidEarsBasic ]
     Chest:
-      points: 4 # Frontier 1<4
+      points: 35 # Frontier 1<4
       required: false
     Legs:
-      points: 8 # Frontier 2<8
+      points: 35 # Frontier 2<8
       required: false
     Arms:
-      points: 8 # Frontier 2<8
+      points: 35 # Frontier 2<8
       required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
     Head:
-      points: 4
+      points: 35
       required: false
     Snout:
-      points: 1
+      points: 35
       required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
+

--- a/Resources/Prototypes/Nyanotrasen/Species/oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Species/oni.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Oni
   name: species-name-oni
@@ -18,32 +19,79 @@
   id: MobOniMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ OniHornSingleCurved ]
     Tail: # Frontier
-      points: 1 # Frontier
+      points: 35 # Frontier
       required: false # Frontier
     Chest:
-      points: 4 # Frontier 1<4
+      points: 35 # Frontier 1<4
       required: false
     Legs:
-      points: 8 # Frontier 2<8
+      points: 35 # Frontier 2<8
       required: false
     Arms:
-      points: 8 # Frontier 2<8
+      points: 35 # Frontier 2<8
+      required: false
+    Head:
+      points: 35
+      required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Snout:
+      points: 35
+      required: false
+    Special:
+      points: 35
       required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
+

--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Arachnid
   name: species-name-arachnid
@@ -52,30 +53,79 @@
   onlyWhitelisted: true
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ ArachnidAppendagesDefault ]
     HeadTop:
-      points: 1
+      points: 35
       required: false
     HeadSide:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ ArachnidCheliceraeDownwards ]
     Chest:
-      points: 2
+      points: 35
       required: false
     Legs:
-      points: 8 # imp 2<8
+      points: 35 # imp 2<8
       required: false
     Arms:
-      points: 8 # imp 2<8
+      points: 35 # imp 2<8
+      required: false
+    Head:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Snout:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    UndergarmentBottom: # THJESE GUYS GIGNT HAVE UNDERWEAR????????? I HATE THAIS ATHSOIAZSDFNIMADSOFI
+      points: 35
+      required: false
+    UndergarmentTop:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/diona.yml
+++ b/Resources/Prototypes/Species/diona.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Diona
   name: species-name-diona
@@ -43,33 +44,79 @@
   onlyWhitelisted: true
   points:
     Head:
-      points: 2
+      points: 35
       required: false
     HeadTop:
-      points: 1
+      points: 35
       required: false
     HeadSide:
-      points: 1
+      points: 35
       required: false
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     Chest:
-      points: 2
+      points: 35
       required: false
     Legs:
-      points: 2
+      points: 35
       required: false
     Arms:
-      points: 2
+      points: 35
       required: false
     Overlay:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ DionaVineOverlay ]
+    FacialHair:
+      points: 35
+      required: false
+    Hair:
+      points: 35
+      required: false
+    Snout:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    Tail:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
 
 - type: humanoidBaseSprite
   id: MobDionaEyes

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Human
   name: species-name-human
@@ -48,37 +49,77 @@
   id: MobHumanMarkingLimits
   points:
     Special: # the cat ear joke
-      points: 3
+      points: 35
       required: false
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Snout:
-      points: 3
+      points: 35
       required: false
     Tail: # the cat tail joke
-      points: 5
+      points: 35
       required: false
     HeadTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     Chest:
-      points: 4
+      points: 35
       required: false
     Legs:
-      points: 8 # imp 2<8
+      points: 35 # imp 2<8
       required: false
     Arms:
-      points: 8 # imp 2<8
+      points: 35 # imp 2<8
+      required: false
+    Head:
+      points: 35
+      required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Moth
   name: species-name-moth
@@ -50,42 +51,79 @@
   onlyWhitelisted: true
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ MothWingsDefault ]
     Snout:
-      points: 1
+      points: 35
       required: false
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ MothAntennasDefault ]
     HeadSide:
-      points: 1
+      points: 35
       required: false
     Head:
-      points: 4 # imp 1<4
+      points: 35 # imp 1<4
       required: false
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     Chest:
-      points: 4 # imp 2<4
+      points: 35 # imp 2<4
       required: false
     Legs:
-      points: 4 # imp 2<4
+      points: 35 # imp 2<4
       required: false
     Arms:
-      points: 4 # imp 2<4
+      points: 35 # imp 2<4
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Reptilian
   name: species-name-reptilian
@@ -46,39 +47,79 @@
   onlyWhitelisted: false
   points:
     Hair:
-      points: 3
+      points: 35
       required: false
     FacialHair:
-      points: 3
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ LizardTailLarge ]
     Snout:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ LizardSnoutRound ]
     HeadTop:
-      points: 4
+      points: 35
       required: false
     HeadSide:
-      points: 4
+      points: 35
       required: false
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     Chest:
-      points: 4 # imp 3<4
+      points: 35 # imp 3<4
       required: false
     Legs:
-      points: 8 # imp 2<8
+      points: 35 # imp 2<8
       required: false
     Arms:
-      points: 8 # imp 2<8
+      points: 35 # imp 2<8
+      required: false
+    Head:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: SlimePerson
   name: species-name-slime
@@ -43,38 +44,80 @@
   id: MobSlimeMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 10
+      points: 35
       required: false
     Head:
-      points: 10
+      points: 35
       required: false
     Legs:
-      points: 10
+      points: 35
       required: false
     Arms:
-      points: 10
+      points: 35
       required: false
     Snout:
-      points: 10
+      points: 35
       required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
     HeadTop:
-      points: 10
+      points: 35
       required: false
-
+    Chest:
+      points: 35
+      required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
 
 - type: humanoidBaseSprite
   id: MobSlimeMarkingFollowSkin

--- a/Resources/Prototypes/_DV/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Species/feroxi.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Feroxi
   name: species-name-feroxi
@@ -46,43 +47,83 @@
   id: MobFeroxiMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Head:
-      points: 3
+      points: 35
       required: false
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ FeroxiEars ]
     Snout:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ FeroxiSnout ]
     Chest:
-      points: 3
+      points: 35
       required: false
     Arms:
-      points: 1
+      points: 35
       required: false
     Legs:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ FeroxiTailAndDorsal ]
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
 
 - type: humanoidBaseSprite
   id: MobFeroxiHead

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Harpy
   name: species-name-harpy
@@ -44,38 +45,84 @@
   id: MobHarpyMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ HarpyTailPhoenix ]
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ HarpyEarsDefault ]
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
     Chest:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ HarpyChestDefault ]
     Legs:
-      points: 2
+      points: 35
       required: false
     Arms:
-      points: 1
+      points: 35
       required: false
       defaultMarkings: [ HarpyWingDefaultHuescale ]
+    Head:
+      points: 35
+      required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Snout:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
 
 - type: humanoidBaseSprite
   id: MobHarpyHead

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Rodentia
   name: species-name-rodentia
@@ -48,44 +49,81 @@
   id: MobRodentiaMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ RodentiaTailDefault ]
     Legs:
-      points: 4
+      points: 35
       required: false
     Arms:
-      points: 4
+      points: 35
       required: false
     Snout:
-      points: 1
+      points: 35
       required: false
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ RodentiaHeadTopEarDefault ]
     HeadSide:
-      points: 1
+      points: 35
       required: false
     Chest:
-      points: 2
+      points: 35
+      required: false
+    Head:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
       required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
     Special: # the cat ear joke
-      points: 3
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_DV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Species/vulpkanin.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Vulpkanin
   name: species-name-vulpkanin
@@ -46,39 +47,80 @@
   id: MobVulpkaninMarkingLimits
   points:
     Hair:
-      points: 4
+      points: 35
       required: false
     FacialHair:
-      points: 4
+      points: 35
       required: false
     Tail:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ VulpTail ]
     Head:
-      points: 4
+      points: 35
       required: false
     Legs:
-      points: 4
+      points: 35
       required: false
     Arms:
-      points: 4
+      points: 35
       required: false
     Snout:
-      points: 1
+      points: 35
       required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ VulpEar ]
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
+    Chest:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+
 
 - type: humanoidBaseSprite
   id: MobVulpkaninHead

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/bishop.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/bishop.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -13,7 +13,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopHeadAlt
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -23,7 +23,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopHeadAlt1
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -33,7 +33,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -45,7 +45,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -70,7 +70,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -91,7 +91,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -115,7 +115,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC, Moth, Dwarf, Human, Arachnid, Felinid, Oni, Vulpkanin, HumanoidFoxes, Reptilian, Feroxi]
   sprites:
@@ -127,7 +127,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC, Moth, Dwarf, Human, Arachnid, Felinid, Oni, Vulpkanin, HumanoidFoxes, Reptilian, Feroxi]
   sprites:
@@ -142,7 +142,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC, Moth, Dwarf, Human, Arachnid, Felinid, Oni, Vulpkanin, HumanoidFoxes, Reptilian, Feroxi]
   sprites:
@@ -152,7 +152,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC, Moth, Dwarf, Human, Arachnid, Felinid, Oni, Vulpkanin, HumanoidFoxes, Reptilian, Feroxi]
   sprites:
@@ -165,7 +165,7 @@
 - type: marking
   id: CyberLimbsMarkingBishopRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC, Moth, Dwarf, Human, Arachnid, Felinid, Oni, Vulpkanin, HumanoidFoxes, Reptilian, Feroxi]
   sprites:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/hephiastos.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/hephiastos.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -13,7 +13,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosHeadAlt
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -27,7 +27,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -39,7 +39,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -62,7 +62,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -85,7 +85,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -109,7 +109,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -134,7 +134,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -158,7 +158,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -182,7 +182,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC
@@ -206,7 +206,7 @@
 - type: marking
   id: CyberLimbsMarkingHesphiastosRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction:
   - IPC

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/morpheus.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/morpheus.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -16,7 +16,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusHeadAlt
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -31,7 +31,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -46,7 +46,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -61,7 +61,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -76,7 +76,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -92,7 +92,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -109,7 +109,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -125,7 +125,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -140,7 +140,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:
@@ -156,7 +156,7 @@
 - type: marking
   id: CyberLimbsMarkingMorpheusRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   coloring:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/shellguard.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/shellguard.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -13,7 +13,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardHeadAlt
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -25,7 +25,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -37,7 +37,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -49,7 +49,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -61,7 +61,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -74,7 +74,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -88,7 +88,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -101,7 +101,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -113,7 +113,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -126,7 +126,7 @@
 - type: marking
   id: CyberLimbsMarkingShellguardRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/wardtakahashi.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/wardtakahashi.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -11,7 +11,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiHeadAlt
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -21,7 +21,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiHeadAlt1
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -31,7 +31,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -41,7 +41,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -51,7 +51,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -61,7 +61,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -72,7 +72,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -84,7 +84,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -95,7 +95,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -105,7 +105,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -116,7 +116,7 @@
 - type: marking
   id: CyberLimbsMarkingWardtakahashiRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/xion.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/xion.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingXionHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -13,7 +13,7 @@
 - type: marking
   id: CyberLimbsMarkingXionHeadAlt
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -25,7 +25,7 @@
 - type: marking
   id: CyberLimbsMarkingXionChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -37,7 +37,7 @@
 - type: marking
   id: CyberLimbsMarkingXionLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -49,7 +49,7 @@
 - type: marking
   id: CyberLimbsMarkingXionLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -61,7 +61,7 @@
 - type: marking
   id: CyberLimbsMarkingXionLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -74,7 +74,7 @@
 - type: marking
   id: CyberLimbsMarkingXionLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -88,7 +88,7 @@
 - type: marking
   id: CyberLimbsMarkingXionRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -102,7 +102,7 @@
 - type: marking
   id: CyberLimbsMarkingXionRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -114,7 +114,7 @@
 - type: marking
   id: CyberLimbsMarkingXionRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -127,7 +127,7 @@
 - type: marking
   id: CyberLimbsMarkingXionRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/zenghu.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Customization/zenghu.yml
@@ -1,7 +1,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuHead
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -13,7 +13,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuChest
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -25,7 +25,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -37,7 +37,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -49,7 +49,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -62,7 +62,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -76,7 +76,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -90,7 +90,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -102,7 +102,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:
@@ -115,7 +115,7 @@
 - type: marking
   id: CyberLimbsMarkingZenghuRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [IPC]
   sprites:

--- a/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/ipc.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: IPC
   name: species-name-ipc
@@ -59,50 +60,84 @@
   id: MobIPCMarkingLimits
   points:
     Hair:
-      points: 4
+      points: 35
       required: false
     Head:
-      points: 3
+      points: 35
       required: true
       defaultMarkings: [ MobIPCHeadDefault ]
     Chest:
-      points: 3
+      points: 35
       required: true
       defaultMarkings: [ MobIPCTorsoDefault ]
     Legs:
-      points: 4
+      points: 35
       required: true
       defaultMarkings: [ MobIPCLLegDefault, MobIPCLFootDefault, MobIPCRLegDefault, MobIPCRFootDefault ]
     Arms:
-      points: 4
+      points: 35
       required: true
       defaultMarkings: [ MobIPCLArmDefault, MobIPCLHandDefault, MobIPCRArmDefault, MobIPCRHandDefault ]
     HeadSide:
-      points: 3
+      points: 35
       required: false
     Tail:
-      points: 4
+      points: 35
       required: false
     Snout:
-      points: 4
+      points: 35
       required: false
     # Frontier: apparently these don't exist on Delta
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     # End Frontier
     HeadTop:
-      points: 4
+      points: 35
       required: false
     FacialHair:
-      points: 4
+      points: 35
       required: false
-
-
-
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
+      required: false
 
 - type: humanoidBaseSprite
   id: MobIPCMarkingFollowSkin

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/markings/species_adaptors.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/markings/species_adaptors.yml
@@ -8,7 +8,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninHeadMale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -18,7 +18,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninHeadFemale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -28,7 +28,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninTorsoMale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -38,7 +38,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninTorsoFemale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -48,7 +48,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -58,7 +58,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -68,7 +68,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -78,7 +78,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -88,7 +88,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -98,7 +98,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -108,7 +108,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -118,7 +118,7 @@
 - type: marking
   id: SpeciesAdaptorVulpkaninRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -129,7 +129,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaHeadMale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -139,7 +139,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaHeadFemale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -149,7 +149,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaTorsoMale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -159,7 +159,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaTorsoFemale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -169,7 +169,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -179,7 +179,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -189,7 +189,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -199,7 +199,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -209,7 +209,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -219,7 +219,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -229,7 +229,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -239,7 +239,7 @@
 - type: marking
   id: SpeciesAdaptorRodentiaRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -250,7 +250,7 @@
 - type: marking
   id: SpeciesAdaptorHumanHeadMale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -260,7 +260,7 @@
 - type: marking
   id: SpeciesAdaptorHumanHeadFemale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -270,7 +270,7 @@
 - type: marking
   id: SpeciesAdaptorHumanTorsoMale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -280,7 +280,7 @@
 - type: marking
   id: SpeciesAdaptorHumanTorsoFemale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -290,7 +290,7 @@
 - type: marking
   id: SpeciesAdaptorHumanLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -300,7 +300,7 @@
 - type: marking
   id: SpeciesAdaptorHumanLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -310,7 +310,7 @@
 - type: marking
   id: SpeciesAdaptorHumanRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -320,7 +320,7 @@
 - type: marking
   id: SpeciesAdaptorHumanRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -330,7 +330,7 @@
 - type: marking
   id: SpeciesAdaptorHumanLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -340,7 +340,7 @@
 - type: marking
   id: SpeciesAdaptorHumanLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -350,7 +350,7 @@
 - type: marking
   id: SpeciesAdaptorHumanRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -360,7 +360,7 @@
 - type: marking
   id: SpeciesAdaptorHumanRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -371,7 +371,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiHeadMale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -381,7 +381,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiHeadFemale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -391,7 +391,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiTorsoMale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -401,7 +401,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiTorsoFemale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -411,7 +411,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -421,7 +421,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -431,7 +431,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -441,7 +441,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -451,7 +451,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -461,7 +461,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -471,7 +471,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -481,7 +481,7 @@
 - type: marking
   id: SpeciesAdaptorFeroxiRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -492,7 +492,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianHeadMale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -502,7 +502,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianHeadFemale
   bodyPart: Head
-  markingCategory: Head
+  markingCategory: BaseHead
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -512,7 +512,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianTorsoMale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -522,7 +522,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianTorsoFemale
   bodyPart: Chest
-  markingCategory: Chest
+  markingCategory: BaseChest
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -532,7 +532,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianLArm
   bodyPart: LArm
-  markingCategory: Arms
+  markingCategory: BaseLArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -542,7 +542,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianLHand
   bodyPart: LHand
-  markingCategory: Arms
+  markingCategory: BaseLHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -552,7 +552,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianRArm
   bodyPart: RArm
-  markingCategory: Arms
+  markingCategory: BaseRArm
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -562,7 +562,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianRHand
   bodyPart: RHand
-  markingCategory: Arms
+  markingCategory: BaseRHand
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -572,7 +572,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianLLeg
   bodyPart: LLeg
-  markingCategory: Legs
+  markingCategory: BaseLLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -582,7 +582,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianLFoot
   bodyPart: LFoot
-  markingCategory: Legs
+  markingCategory: BaseLFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -592,7 +592,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianRLeg
   bodyPart: RLeg
-  markingCategory: Legs
+  markingCategory: BaseRLeg
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:
@@ -602,7 +602,7 @@
 - type: marking
   id: SpeciesAdaptorReptilianRFoot
   bodyPart: RFoot
-  markingCategory: Legs
+  markingCategory: BaseRFoot
   kindAllowance: [BasicHumanlike, BasicFurry]
   speciesRestriction: [Vulpkanin, SlimePerson, Human, Rodentia, Feroxi, Oni, IPC, Reptilian]
   sprites:

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/moth.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/moth.yml
@@ -72,22 +72,6 @@
     state: arm_l_chimera_moth
 
 - type: marking
-  id: ProstheticArmLeftMoth
-  bodyPart: LArm
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: arm_l_prosthetic_moth
-
-- type: marking
   id: TwistingArmLeftMoth
   bodyPart: LArm
   markingCategory: Arms
@@ -97,22 +81,6 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/moth.rsi
     state: arm_l_twisting_moth
-
-- type: marking
-  id: ProstheticArmRightMoth
-  bodyPart: RArm
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: arm_r_prosthetic_moth
 
 - type: marking
   id: TwistingArmRightMoth
@@ -262,38 +230,6 @@
     state: foot_l_chimera_moth
 
 - type: marking
-  id: FootProstheticLeftMoth
-  bodyPart: LFoot
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: foot_l_prosthetic_moth
-
-- type: marking
-  id: FootProstheticRightMoth
-  bodyPart: RFoot
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: foot_r_prosthetic_moth
-
-- type: marking
   id: HandChimeraLeftMoth
   bodyPart: LHand
   markingCategory: Arms
@@ -310,22 +246,6 @@
     state: hand_l_chimera_moth
 
 - type: marking
-  id: HandProstheticLeftMoth
-  bodyPart: LHand
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: hand_l_prosthetic_moth
-
-- type: marking
   id: HandTwistingLeftMoth
   bodyPart: LHand
   markingCategory: Arms
@@ -335,22 +255,6 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/moth.rsi
     state: hand_l_twisting_moth
-
-- type: marking
-  id: HandProstheticRightMoth
-  bodyPart: RHand
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: hand_r_prosthetic_moth
 
 - type: marking
   id: HandTwistingRightMoth
@@ -429,22 +333,6 @@
     state: leg_l_chimera_moth
 
 - type: marking
-  id: LegProstheticLeftMoth
-  bodyPart: LLeg
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: leg_l_prosthetic_moth
-
-- type: marking
   id: LegTwistingLeftMoth
   bodyPart: LLeg
   markingCategory: Legs
@@ -454,22 +342,6 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/moth.rsi
     state: leg_l_twisting_moth
-
-- type: marking
-  id: LegProstheticRightMoth
-  bodyPart: RLeg
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Moth]
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/moth.rsi
-    state: leg_r_prosthetic_moth
 
 - type: marking
   id: LegTwistingRightMoth
@@ -492,3 +364,131 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/moth.rsi
     state: torso_incision_moth
+
+- type: marking
+  id: ProstheticArmLeftMoth
+  bodyPart: LArm
+  markingCategory: BaseLArm
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: arm_l_prosthetic_moth
+
+- type: marking
+  id: ProstheticArmRightMoth
+  bodyPart: RArm
+  markingCategory: BaseRArm
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: arm_r_prosthetic_moth
+
+- type: marking
+  id: FootProstheticLeftMoth
+  bodyPart: LFoot
+  markingCategory: BaseLFoot
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: foot_l_prosthetic_moth
+
+- type: marking
+  id: FootProstheticRightMoth
+  bodyPart: RFoot
+  markingCategory: BaseRFoot
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: foot_r_prosthetic_moth
+
+- type: marking
+  id: HandProstheticLeftMoth
+  bodyPart: LHand
+  markingCategory: BaseLHand
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: hand_l_prosthetic_moth
+
+- type: marking
+  id: HandProstheticRightMoth
+  bodyPart: RHand
+  markingCategory: BaseRHand
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: hand_r_prosthetic_moth
+
+- type: marking
+  id: LegProstheticLeftMoth
+  bodyPart: LLeg
+  markingCategory: BaseLLeg
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: leg_l_prosthetic_moth
+
+- type: marking
+  id: LegProstheticRightMoth
+  bodyPart: RLeg
+  markingCategory: BaseRLeg
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Moth]
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/moth.rsi
+    state: leg_r_prosthetic_moth

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/scars.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/scars.yml
@@ -1,18 +1,3 @@
-- type: marking
-  id: ArmProstheticLeft
-  bodyPart: LArm
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: arm_l_prosthetic
 
 - type: marking
   id: ArmTwistingLeft
@@ -24,22 +9,6 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/scars.rsi
     state: arm_l_twisting
-
-- type: marking
-  id: ArmProstheticRight
-  bodyPart: RArm
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: arm_r_prosthetic
 
 - type: marking
   id: ArmTwistingRight
@@ -97,54 +66,6 @@
     state: chest_star
 
 - type: marking
-  id: FootProstheticLeft
-  bodyPart: LFoot
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: foot_l_prosthetic
-
-- type: marking
-  id: FootProstheticRight
-  bodyPart: RFoot
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: foot_r_prosthetic
-
-- type: marking
-  id: HandProstheticLeft
-  bodyPart: LHand
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: hand_l_prosthetic
-
-- type: marking
   id: HandTwistingLeft
   bodyPart: LHand
   markingCategory: Arms
@@ -154,22 +75,6 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/scars.rsi
     state: hand_l_twisting
-
-- type: marking
-  id: HandProstheticRight
-  bodyPart: RHand
-  markingCategory: Arms
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: hand_r_prosthetic
 
 - type: marking
   id: HandTwistingRight
@@ -205,22 +110,6 @@
     state: head_twisting
 
 - type: marking
-  id: LegProstheticLeft
-  bodyPart: LLeg
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: leg_l_prosthetic
-
-- type: marking
   id: LegTwistingLeft
   bodyPart: LLeg
   markingCategory: Legs
@@ -230,22 +119,6 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/scars.rsi
     state: leg_l_twisting
-
-- type: marking
-  id: LegProstheticRight
-  bodyPart: RLeg
-  markingCategory: Legs
-  kindAllowance: [BasicHumanlike, BasicFurry]
-  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
-  followSkinColor: false
-  coloring:
-    default:
-      type:
-        !type:SimpleColoring
-          color: "#E4E4E4"
-  sprites:
-  - sprite: _Impstation/Mobs/Customization/scars.rsi
-    state: leg_r_prosthetic
 
 - type: marking
   id: LegTwistingRight
@@ -268,3 +141,133 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/scars.rsi
     state: torso_incision
+
+# COYOTE moved these down here cus prosthetics
+- type: marking
+  id: ArmProstheticLeft
+  bodyPart: LArm
+  markingCategory: BaseLArm
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: arm_l_prosthetic
+
+- type: marking
+  id: ArmProstheticRight
+  bodyPart: RArm
+  markingCategory: BaseRArm
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: arm_r_prosthetic
+
+- type: marking
+  id: FootProstheticLeft
+  bodyPart: LFoot
+  markingCategory: BaseLFoot
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: foot_l_prosthetic
+
+- type: marking
+  id: FootProstheticRight
+  bodyPart: RFoot
+  markingCategory: BaseRFoot
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: foot_r_prosthetic
+
+- type: marking
+  id: HandProstheticLeft
+  bodyPart: LHand
+  markingCategory: BaseLHand
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: hand_l_prosthetic
+
+- type: marking
+  id: HandProstheticRight
+  bodyPart: RHand
+  markingCategory: BaseRHand
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, Reptilian, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: hand_r_prosthetic
+
+- type: marking
+  id: LegProstheticLeft
+  bodyPart: LLeg
+  markingCategory: BaseLLeg
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: leg_l_prosthetic
+
+- type: marking
+  id: LegProstheticRight
+  bodyPart: RLeg
+  markingCategory: BaseRLeg
+  kindAllowance: [BasicHumanlike, BasicFurry]
+  speciesRestriction: [Human, Dwarf, SlimePerson, Arachnid, Oni, Goblin, Felinid] # Frontier: add Oni, Goblin, Felinid
+  followSkinColor: false
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+        color: "#E4E4E4"
+  sprites:
+  - sprite: _Impstation/Mobs/Customization/scars.rsi
+    state: leg_r_prosthetic
+

--- a/Resources/Prototypes/_NF/Species/goblin.yml
+++ b/Resources/Prototypes/_NF/Species/goblin.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 #  defaultSkinTone: "#486a1b"
 - type: species
   id: Goblin
@@ -46,33 +47,79 @@
   id: MobGoblinMarkingLimits
   points:
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     HeadTop:
-      points: 1
+      points: 35
       required: true
       defaultMarkings: [ GoblinEarsBasic ]
     Snout:
-      points: 2
+      points: 35
       required: false
 #      defaultMarkings: [ GoblinNoseBasic ]
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     Chest:
-      points: 1
+      points: 35
       required: false
     Legs:
-      points: 2
+      points: 35
       required: false
     Arms:
-      points: 2
+      points: 35
+      required: false
+    Head:
+      points: 35
+      required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    Special:
+      points: 35
+      required: false
+    Tail:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 - type: humanoidBaseSprite

--- a/Resources/Prototypes/_NF/Species/sheleg.yml
+++ b/Resources/Prototypes/_NF/Species/sheleg.yml
@@ -1,3 +1,4 @@
+# METATAGS: UpdateMarkingPoints, UpdateSpeciesBaseSprites
 - type: species
   id: Sheleg
   name: species-name-sheleg
@@ -50,37 +51,77 @@
   id: MobShelegMarkingLimits
   points:
     Special: # the cat ear joke
-      points: 0
+      points: 35
       required: false
     Hair:
-      points: 1
+      points: 35
       required: false
     FacialHair:
-      points: 1
+      points: 35
       required: false
     Snout:
-      points: 5
+      points: 35
       required: false
     Tail: # the cat tail joke
-      points: 5
+      points: 35
       required: false
     HeadTop:
-      points: 5
+      points: 35
       required: false
     UndergarmentTop:
-      points: 3
+      points: 35
       required: false
     UndergarmentBottom:
-      points: 3
+      points: 35
       required: false
     Chest:
-      points: 4
+      points: 35
       required: false
     Legs:
-      points: 8
+      points: 35
       required: false
     Arms:
-      points: 8
+      points: 35
+      required: false
+    Head:
+      points: 35
+      required: false
+    HeadSide:
+      points: 35
+      required: false
+    Overlay:
+      points: 35
+      required: false
+    # Copypaste these into every species I HATE THIS CODE
+    BaseChest:
+      points: 35
+      required: false
+    BaseHead:
+      points: 35
+      required: false
+    BaseLArm:
+      points: 35
+      required: false
+    BaseLFoot:
+      points: 35
+      required: false
+    BaseLHand:
+      points: 35
+      required: false
+    BaseLLeg:
+      points: 35
+      required: false
+    BaseRArm:
+      points: 35
+      required: false
+    BaseRFoot:
+      points: 35
+      required: false
+    BaseRHand:
+      points: 35
+      required: false
+    BaseRLeg:
+      points: 35
       required: false
 
 # - type: humanoidBaseSprite


### PR DESCRIPTION
Touches up and equalizes marking limits for everyone once and for all. Also adds in a new set of categories to change the underlying shape/structure of your character's parts (Like your HEAD we dont have NADS yet)

Every species (cept vox and teshari cus fuck them) now has access to every marking category known to furry kind, and each of those categories get 35 slots to fill with markings. Yeah try and run out of slots now. Yes this applies to underwear. yes this applies to that too. And that. 

You know how you'd pick a tail, and you'd need to pick like 5 more to get the default one to go away? Now if you pick something for a category, the default will disappear.

You also know how when you want to change your character's head shape or something, you also have to pick a dozen things to make the base one disappear? Well now theres a bunch of new categories that'll let you overwrite the individual base parts with a single marking, or more if you want! Stick a robot head on a vulpkanin (you monster)! Stick a prosthetic moth arm on a lizard (you monster)! Stick a robot chestpiece on a vulpkanin (you monster)! It'll hide the base sprite on the mob and replace it with *that*!

Note that if you had cybernetic parts, theres a non-zero chance you'll have to re-edit your character's markings. Shouldnt destroy your file though, but you know how this shit is