### PR TITLE
Rebalances Some Xenoarch Numbers

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -64,7 +64,7 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// The amount of points a node is worth with no scaling
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float BasePointValue = 1000; // Frontier: 4000<1000
+    public float BasePointValue = 1400; // Frontier: 4000<1000 Coyote: 1000<1400
 
     /// <summary>
     /// Amount of points available currently for extracting.

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -112,7 +112,7 @@
     - id: XenoArtifactExplosionScary
       weight: 1.0
     - id: XenoArtifactBoom
-      weight: 1.5 # Coyote
+      weight: 1.5 # Coyote: 5.0 < 1.5
     - id: XenoArtifactEffectCreationGasPlasma
       weight: 2.0
     - id: XenoArtifactEffectCreationGasTritium

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -112,7 +112,7 @@
     - id: XenoArtifactExplosionScary
       weight: 1.0
     - id: XenoArtifactBoom
-      weight: 5.0
+      weight: 1.5 # Coyote
     - id: XenoArtifactEffectCreationGasPlasma
       weight: 2.0
     - id: XenoArtifactEffectCreationGasTritium


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR simply reduces the weightage of artifact explosions and also increases the base science point reward by 40%.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Whilst it's funny to roll 3 nodes in a row that explode, it gets boring after the first time. The amount of time spent needed to recover from the explosions also completely kill any sort of momentum you have built up. This compounds even further due to our (comparatively) shorter rounds than upstream.

Increasing the base science reward also helps with our shorter rounds, now scientists can spend more time interacting with people and roleplaying instead of fighting RNG for 5 hours and watch in dismay as everyone has already returned to the station and sold their ships by the time you're "done" (unlock super stock parts) with science.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Toriate
- tweak: Xenoarch artifacts should explode less often now
- tweak: Xenoarch artifacts should provide 40% more science points at base
