### PR TITLE
Opens Brigmedic jobslots by default

### DIFF
--- a/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/nfsd.yml
@@ -47,7 +47,7 @@
             Bailiff: [ 1, 1 ]
             SeniorOfficer: [ 1, 1 ]
             Brigmedic: [ 2, 2 ]
-            NFDetective: [ 2, 2 ]
+            NFDetective: [ 0, 0 ]
             Deputy: [ 3, 3 ]
             Cadet: [ 3, 3 ]
             # Others:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Opens two jobslots each for Brigmedic ~~and Detective~~.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With how rarely Sheriffs ever touch these jobslots, and how many medical-oriented NFSD players we have, it's better off this way. Two each because they're specialists and shouldn't be as numerous as deputies/cadets, but not one only as there is utility in having more than one medically competent member (especially when NFSD runs the Empress or whatever)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Toriate
- tweak: Brigmedic jobslots are now open by default

