### PR TITLE
Renames Trade Mall fax machines to Nash Station

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Machines/fax_machine.yml
@@ -146,7 +146,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: FaxMachine
-    name: "Trade Mall STC"
+    name: "Nash Station Bridge" # Coyote: Replaced Trade Mall with Nash Station. Also renamed STC to Bridge since people may want to fax the SR too.
 
 - type: entity
   parent: [BaseStructureDisableToolUse, FaxMachineBase]
@@ -155,7 +155,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: FaxMachine
-    name: "Trade Mall NFSD Post"
+    name: "Nash Station NFSD Post" # Coyote: Replaced Trade Mall with Nash Station
 
 - type: entity
   parent: [BaseStructureDisableToolUse, FaxMachineBase]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The Nash Station fax machines have had their names corrected. The STC fax machine has also been renamed to Bridge to better convey the idea that both the STC and SR can be reached through the machine.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There is no Trade Mall. It was confusing for no good reason. It's also counterintuitive to send a fax to the STC when you want to get to the SR if you are not aware that the fax machine is in the bridge. A good chunk of players don't even know what the bridge looks like!

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Toriate
- tweak: Nash Station's fax machines are no longer labeled Trade Mall

