### PR TITLE
Removes several immersion ruining lines random sentience

### DIFF
--- a/Resources/Locale/en-US/station-events/events/random-sentience.ftl
+++ b/Resources/Locale/en-US/station-events/events/random-sentience.ftl
@@ -1,7 +1,6 @@
 ﻿## Phrases used for where central command got this information.
 random-sentience-event-data-1 = scans from our long-range sensors
 random-sentience-event-data-2 = our sophisticated probabilistic models
-random-sentience-event-data-3 = our omnipotence
 # Frontier: "from your station"<"within the sector"
 random-sentience-event-data-4 = the communications traffic within the sector
 random-sentience-event-data-5 = energy emissions we detected
@@ -15,9 +14,7 @@ random-sentience-event-strength-3 = moderate
 random-sentience-event-strength-4 = high
 # Frontier: command < genius (......)
 random-sentience-event-strength-5 = genius
-random-sentience-event-strength-6 = clown
 random-sentience-event-strength-7 = low
-random-sentience-event-strength-8 = AI
 
 ## Announcement text
 

--- a/Resources/Locale/en-US/station-events/events/random-sentience.ftl
+++ b/Resources/Locale/en-US/station-events/events/random-sentience.ftl
@@ -2,9 +2,9 @@
 random-sentience-event-data-1 = scans from our long-range sensors
 random-sentience-event-data-2 = our sophisticated probabilistic models
 # Frontier: "from your station"<"within the sector"
-random-sentience-event-data-4 = the communications traffic within the sector
-random-sentience-event-data-5 = energy emissions we detected
-random-sentience-event-data-6 = [REDACTED]
+random-sentience-event-data-3 = the communications traffic within the sector
+random-sentience-event-data-4 = energy emissions we detected
+random-sentience-event-data-5 = [REDACTED]
 
 ## Phrases used to describe the level of intelligence, though it doesn't actually affect anything.
 random-sentience-event-strength-1 = human
@@ -14,7 +14,7 @@ random-sentience-event-strength-3 = moderate
 random-sentience-event-strength-4 = high
 # Frontier: command < genius (......)
 random-sentience-event-strength-5 = genius
-random-sentience-event-strength-7 = low
+random-sentience-event-strength-6 = low
 
 ## Announcement text
 


### PR DESCRIPTION
Alternatives considered: Code in an option to let people opt in/out of pyrovision/pyrohearing.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
A few way to silly (bordering on NRP) lines have been removed form random sentience, APC deactivation will shortly follow since the word "Omnipotence" is used there as well.

## Why / Balance
NT is described as not as powerful as in LRP SS13 or other LRP SS14 servers. Omnipotence therefor is not something they should be able to just have and anyone working in a company and unironically using a public announcement system declaring that they are omnipotent would usually have to go under psychological evaluation.

This basically removes some age old godmoding NT has gotten from the predecessor game. Its immersion ruining at best and not every character is necessarily NT aligned either here.

It also removes some way too memy nonesense in the same random event flavortext.

Since the server is configured to English only the english localization is affected.

Due to **my** Omnscience I think this may also remove the "Omnipotence" line in the APC deactivation event. We will see if thats the case. Just to drive home how nonsensical it is to use such words.

NTs lowered powerscale needs to be reflected both in code and in lore. And the most egregious examples are within random announcement flavortexts. 


## Technical details
It is a removal of a few flavor lines and should not further affect function.

## How to test
Force run the event a couple times and observe how immersion is no longer ruined by NT claiming they are omnipotent or other memy stuff like that they "OwN YoUR SoUl" or "wE ARe ThE SyNDiCaTe".

## Media
Not required, it removes a few lines of code that are exceptionally NRP/silly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

None. 

**Changelog**

:cl:
- remove: Removed NT powercreep in sentience announcement. Hopefully. It also might fix APC deactivations "omnipotence" nonesense.

