### PR TITLE
Thrusters 2: The Rethrustening

### DIFF
--- a/Content.Server/Shuttles/Components/ShuttleComponent.cs
+++ b/Content.Server/Shuttles/Components/ShuttleComponent.cs
@@ -20,7 +20,7 @@ namespace Content.Server.Shuttles.Components
         /// Maximum velocity assuming unupgraded, tier 1 thrusters
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
-        public float BaseMaxLinearVelocity = 20f;
+        public float BaseMaxLinearVelocity = 23.07f;
 
         public const float MaxAngularVelocity = 4f;
 

--- a/Content.Server/Shuttles/Components/ThrusterComponent.cs
+++ b/Content.Server/Shuttles/Components/ThrusterComponent.cs
@@ -71,7 +71,7 @@ namespace Content.Server.Shuttles.Components
         public ProtoId<MachinePartPrototype> MachinePartThrust = "Capacitor";
 
         [DataField]
-        public float[] ThrustPerPartLevel = [130, 150, 180, 250];
+        public float[] ThrustPerPartLevel = [130, 170, 210, 250];
 
         /// <summary>
         /// Load on the power network, in watts.

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters.yml
@@ -3,12 +3,12 @@
   id: SmallThruster
   parent: Thruster
   name: SpacePutt Mini thruster
-  description: A minified version of the SpacePutt Force thruster, for
+  description: A minified version of the SpacePutt Force thruster, for mini shuttles.
   components:
   - type: Thruster
     baseThrust: 33
     thrust: 33
-    thrustPerPartLevel: [33, 37, 42, 65]
+    thrustPerPartLevel: [42.9, 56.1, 69.3, 82.5]
     damage:
       types:
         Heat: 40

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters_but_cooler.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters_but_cooler.yml
@@ -9,7 +9,7 @@
   - type: Thruster
     baseThrust: 33
     thrust: 22
-    thrustPerPartLevel: [22, 23, 24, 25] # its bad
+    thrustPerPartLevel: [28.6, 37, 45.4, 53.8] # its bad
     damage:
       types:
         Heat: 40
@@ -56,7 +56,7 @@
   - type: Thruster
     baseThrust: 200
     thrust: 132
-    thrustPerPartLevel: [132, 145, 165, 200]
+    thrustPerPartLevel: [162, 202, 242, 282]
     damage:
       types:
         Heat: 40
@@ -106,7 +106,7 @@
   - type: Thruster
     baseThrust: 33
     thrust: 60
-    thrustPerPartLevel: [60, 67, 73, 80]
+    thrustPerPartLevel: [78, 96, 114, 132]
     damage:
       types:
         Heat: 40
@@ -153,7 +153,7 @@
   - type: Thruster
     baseThrust: 100
     thrust: 190
-    thrustPerPartLevel: [190, 230, 245, 275]
+    thrustPerPartLevel: [247, 304, 361, 418]
     damage:
       types:
         Heat: 40
@@ -200,7 +200,7 @@
   - type: Thruster
     baseThrust: 33
     thrust: 75
-    thrustPerPartLevel: [75, 85, 95, 110]
+    thrustPerPartLevel: [97.5, 120, 142.5, 165]
     damage:
       types:
         Heat: 40
@@ -247,7 +247,7 @@
   - type: Thruster
     baseThrust: 330
     thrust: 750
-    thrustPerPartLevel: [750, 900, 1350, 2000]
+    thrustPerPartLevel: [975, 1200, 1425, 1650]
     damage:
       types:
         Heat: 40
@@ -300,7 +300,7 @@
   - type: MachineBoard
     prototype: SlowWeakThruster
     requirements: # Frontier
-      Capacitor: 4 # Frontier stackRequirements<requirements
+      Capacitor: 3 # Frontier stackRequirements<requirements
 
 - type: latheRecipe
   parent: [BaseCircuitboardRecipe, BaseEngineeringMachineRecipeCategory, BaseGeneralMachineRecipeCategory]
@@ -320,7 +320,7 @@
   - type: MachineBoard
     prototype: SlowStrongThruster
     requirements: # Frontier
-      Capacitor: 4 # Frontier stackRequirements<requirements
+      Capacitor: 3 # Frontier stackRequirements<requirements
 
 - type: latheRecipe
   parent: [BaseCircuitboardRecipe, BaseEngineeringMachineRecipeCategory, BaseGeneralMachineRecipeCategory]
@@ -342,20 +342,16 @@
     requirements: # Frontier
       Capacitor: 5 # Frontier stackRequirements<requirements
     stackRequirements:
-      Steel: 15
-      Uranium: 10
-      Gold: 10
+      Steel: 5
 
 - type: latheRecipe
   parent: [BaseCircuitboardRecipe, BaseEngineeringMachineRecipeCategory, BaseGeneralMachineRecipeCategory]
   id: FastWeakThrusterMachineCircuitboard
   result: FastWeakThrusterMachineCircuitboard
   materials:
-    Steel: 700
-    Glass: 1500
-    Plastic: 2000
-    Gold: 1000
-    Silver: 1000
+    Steel: 800
+    Glass: 900
+    Gold: 100
 
 #region TurboPutt Dragon
 - type: entity
@@ -370,22 +366,18 @@
   - type: MachineBoard
     prototype: FastStrongThruster
     requirements: # Frontier
-      Capacitor: 6 # Frontier stackRequirements<requirements
+      Capacitor: 5 # Frontier stackRequirements<requirements
     stackRequirements:
-      Steel: 20
-      Uranium: 15
-      Gold: 15
+      Steel: 10
 
 - type: latheRecipe
   parent: [BaseCircuitboardRecipe, BaseEngineeringMachineRecipeCategory, BaseGeneralMachineRecipeCategory]
   id: FastStrongThrusterMachineCircuitboard
   result: FastStrongThrusterMachineCircuitboard
   materials:
-    Steel: 1500
-    Glass: 3000
-    Plastic: 4000
-    Gold: 2000
-    Silver: 2000
+    Steel: 800
+    Glass: 900
+    Gold: 100
 
 #region UltraPutt Vesper
 - type: entity
@@ -400,27 +392,20 @@
   - type: MachineBoard
     prototype: FasterWeakThruster
     requirements: # Frontier
-      Capacitor: 7 # Frontier stackRequirements<requirements
+      Capacitor: 6 # Frontier stackRequirements<requirements
     stackRequirements:
-      Steel: 60
-      Glass: 100
-      Uranium: 30
-      Gold: 30
-      Bananium: 20
-      Brass: 10
-      Bluespace: 1
+      Steel: 10
+      Plasma: 5
 
 - type: latheRecipe
   parent: [BaseCircuitboardRecipe, BaseEngineeringMachineRecipeCategory, BaseGeneralMachineRecipeCategory]
   id: FasterWeakThrusterMachineCircuitboard
   result: FasterWeakThrusterMachineCircuitboard
   materials:
-    Steel: 3000
-    Glass: 6000
-    Plastic: 8000
-    Gold: 4000
-    Silver: 4000
-    Bananium: 2000
+    Steel: 800
+    Glass: 900
+    Gold: 200
+    Plasma: 100
 
 #region UltraPutt Titan
 - type: entity
@@ -437,28 +422,20 @@
   - type: MachineBoard
     prototype: FasterStrongThruster
     requirements: # Frontier
-      Capacitor: 8 # Frontier stackRequirements<requirements
+      Capacitor: 6 # Frontier stackRequirements<requirements
     stackRequirements:
-      Steel: 120
-      Glass: 200
-      Uranium: 60
-      Gold: 60
-      Bananium: 40
-      Brass: 30
-      Bluespace: 1
-      Diamond: 1
+      Steel: 20
+      Plasma: 10
 
 - type: latheRecipe
   parent: [BaseCircuitboardRecipe, BaseEngineeringMachineRecipeCategory, BaseGeneralMachineRecipeCategory]
   id: FasterStrongThrusterMachineCircuitboard
   result: FasterStrongThrusterMachineCircuitboard
   materials:
-    Steel: 6000
-    Glass: 12000
-    Plastic: 16000
-    Gold: 8000
-    Silver: 8000
-    Bananium: 4000
+    Steel: 800
+    Glass: 900
+    Gold: 200
+    Plasma: 100
 
 #region tags i guess
 - type: Tag

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters_but_cooler.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters_but_cooler.yml
@@ -252,7 +252,7 @@
       types:
         Heat: 40
   - type: ApcPowerReceiver
-    powerLoad: 100000 # This is a lot of power, but it is a super thruster after all
+    powerLoad: 50000 # This is a lot of power, but it is a super thruster after all
   - type: Sprite
     sprite: _NF/Structures/Shuttles/thruster.rsi # Frontier: use _NF prefix
     layers:
@@ -415,7 +415,7 @@
   description: A machine board for the UltraPutt Titan thruster.
     It is the ultimate in going unreasonably fast with extreme acceleration and thrust,
     but it requires a LOT of power to run. Fully upgraded, just one can fly an Ambition.
-    Be sure to upgrade your power systems first! It uses around 100kW of power, each.
+    Be sure to upgrade your power systems first! It uses around 50kW of power, each.
   components:
   - type: Sprite
     state: supply

--- a/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters_but_cooler.yml
+++ b/Resources/Prototypes/_NF/Entities/Structures/Shuttles/thrusters_but_cooler.yml
@@ -436,6 +436,7 @@
     Glass: 900
     Gold: 200
     Plasma: 100
+    Diamond: 100
 
 #region tags i guess
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This PR rebalances thrusters and brings them up to par with upstream's standards. All thrusters should be faster in general, the effort required to construct the advanced thrusters are reduced to sane values, and upgrade effects are no longer skewed towards preferring bluespace capacitors.

All changes are made with the goal of respecting players time and effort. No longer will you spend 3 hours mining the resources needed for printing out the advanced thrusters circuit boards only to realize you need 4x more materials to actually construct the thruster.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Our basic thrusters are currently slower than upstream's, even when upgraded. This also compounds onto our shorter round times. The advanced thrusters take an absurd amount of time and effort invested to procure as well, which in addition to being wildly inaccessible in stark contrast to everything else in-game, is also incommensurate to their actual performance.

This PR mainly reverts the nerf to base thruster upgrades, then applies a consistent additive 30% thrust increase logic across all upgrade tiers. Construction costs are rebalanced to appropriate values in line with other circuitboards and machinery.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Thrusters have been rebalanced to be faster in general and have more consistent upgrade bonuses, in addition to the advanced thrusters having sane construction costs.
-->
