### PR TITLE
the pendulum swings: adjusted weapon changes for round 2 of testing

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_mercenaries.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_mercenaries.yml
@@ -142,7 +142,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgePistol35Overpressure
+    proto: NFCartridgePistol35
     capacity: 4
     count: 4
   - type: Gun
@@ -188,7 +188,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgeRifle20Overpressure
+    proto: NFCartridgeRifle20
     capacity: 10
     count: 10
   - type: Gun
@@ -285,7 +285,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgePistol35Overpressure
+    proto: NFCartridgePistol35
     capacity: 6
     count: 6
   - type: Gun
@@ -337,14 +337,14 @@
     rechargeSound:
       path: /Audio/_NF/Effects/silence.ogg
   - type: BasicEntityAmmoProvider
-    proto: NFShellShotgunBuckshotOverpressure
+    proto: NFShellShotgunBuckshot
     capacity: 1
     count: 1
   - type: Gun
     showExamineText: false
     fireRate: 2
-    minAngle: 10
-    maxAngle: 20
+    minAngle: 25
+    maxAngle: 50
     angleIncrease: 5
     angleDecay: 3
     selectedMode: SemiAuto
@@ -454,7 +454,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgeRifle25Overpressure
+    proto: NFCartridgeRifle25
     capacity: 2
     count: 2
   - type: RechargeBasicEntityAmmo
@@ -511,7 +511,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgeRifle30Overpressure
+    proto: NFCartridgeRifle30
     capacity: 10
     count: 10
   - type: Gun

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_syndicate.yml
@@ -59,7 +59,7 @@
       rechargeSound:
         path: /Audio/_NF/Effects/silence.ogg
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgePistol45Uranium
+      proto: NFCartridgePistol45
       capacity: 1
       count: 1
     - type: Gun
@@ -79,7 +79,7 @@
       prototypes:
         - SyndicateNavalCaptainGearB
     - type: BasicEntityAmmoProvider
-      proto: NFBulletPistol45Incendiary
+      proto: NFBulletPistol45
       capacity: 1
       count: 1
 
@@ -92,7 +92,7 @@
       prototypes:
         - SyndicateNavalCaptainGearC
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgePistol45Overpressure
+      proto: NFCartridgePistol45
       capacity: 1
       count: 1
 
@@ -125,7 +125,7 @@
       rechargeSound:
         path: /Audio/_NF/Effects/silence.ogg
     - type: BasicEntityAmmoProvider
-      proto: NFShellShotgunUranium
+      proto: NFShellShotgunBuckshot
       capacity: 1
       count: 1
     - type: Gun
@@ -149,7 +149,7 @@
       prototypes:
         - SyndicateNavalEngineerGearB
     - type: BasicEntityAmmoProvider
-      proto: NFShellShotgunIncendiary
+      proto: NFShellShotgunBuckshot
       capacity: 1
       count: 1
 
@@ -162,7 +162,7 @@
       prototypes:
         - SyndicateNavalEngineerGearC
     - type: BasicEntityAmmoProvider
-      proto: NFShellShotgunBuckshotOverpressure
+      proto: NFShellShotgunBuckshot
       capacity: 1
       count: 1
 
@@ -326,7 +326,7 @@
       rechargeSound:
         path: /Audio/_NF/Effects/silence.ogg
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgePistol35Uranium
+      proto: NFCartridgePistol35
       capacity: 7
       count: 7
     - type: Gun
@@ -368,7 +368,7 @@
       prototypes:
         - SyndicateNavalOperatorGearD
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgePistol35Overpressure
+      proto: NFCartridgePistol35
       capacity: 7
       count: 7
 
@@ -551,7 +551,7 @@
       rechargeSound:
         path: /Audio/_NF/Effects/silence.ogg
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgeRifle25Uranium
+      proto: NFCartridgeRifle25
       capacity: 4
       count: 4
     - type: Gun
@@ -571,7 +571,7 @@
       prototypes:
         - SyndicateNavalCommanderGearB
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgeRifle25Incendiary
+      proto: NFCartridgeRifle25
       capacity: 4
       count: 4
     - type: Gun
@@ -591,7 +591,7 @@
       prototypes:
         - SyndicateNavalCommanderGearC
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgeRifle25Overpressure
+      proto: NFCartridgeRifle25
       capacity: 4
       count: 4
 
@@ -624,11 +624,13 @@
       rechargeSound:
         path: /Audio/_NF/Effects/silence.ogg
     - type: BasicEntityAmmoProvider
-      proto: NFBulletPistol35Uranium
+      proto: NFBulletPistol35
       capacity: 4
       count: 4
     - type: Gun
       showExamineText: false
+      minAngle: 5
+      maxAngle: 15
       fireRate: 0.5
       selectedMode: FullAuto
       availableModes:
@@ -644,7 +646,7 @@
       prototypes:
         - SyndicateNavalDeckhandGearB
     - type: BasicEntityAmmoProvider
-      proto: NFBulletPistol35Incendiary
+      proto: NFBulletPistol35
       capacity: 4
       count: 4
 
@@ -657,7 +659,7 @@
       prototypes:
         - SyndicateNavalDeckhandGearC
     - type: BasicEntityAmmoProvider
-      proto: NFBulletPistol35Overpressure
+      proto: NFBulletPistol35
       capacity: 4
       count: 4
 
@@ -774,7 +776,7 @@
       prototypes:
         - SyndicateNavalCaptainVoidGear
     - type: BasicEntityAmmoProvider
-      proto: NFCartridgePistol45Uranium
+      proto: NFCartridgePistol45
       capacity: 1
       count: 1
 
@@ -819,7 +821,7 @@
       prototypes:
         - SyndicateNavalEngineerVoidGear
     - type: BasicEntityAmmoProvider
-      proto: NFShellShotgunUranium
+      proto: NFShellShotgunBuckshot
       capacity: 1
       count: 1
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/base_bullets.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/base_bullets.yml
@@ -175,11 +175,11 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
+        Blunt: 0
     soundHit:
       path: /Audio/Weapons/Guns/Hits/snap.ogg
   - type: StaminaDamageOnCollide
-    damage: 15
+    damage: 41
   - type: Tracer
     color: "#00b0ffFF"
     length: 1.5
@@ -229,7 +229,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8
+        Piercing: 22
     ignoreResistances: true
   - type: Tracer
     color: "#666666FF"
@@ -244,7 +244,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 95
         Structural: 200
     penetrationThreshold: 360
     penetrationDamageTypeRequirement:
@@ -261,9 +261,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10
+        Blunt: 0
   - type: StaminaDamageOnCollide
-    damage: 60
+    damage: 95
   - type: Tracer
     color: "#00b0ffFF"
     length: 3

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/base_bullets.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/base_bullets.yml
@@ -229,7 +229,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 24
+        Piercing: 8
     ignoreResistances: true
   - type: Tracer
     color: "#666666FF"
@@ -244,7 +244,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 90
+        Piercing: 30
         Structural: 200
     penetrationThreshold: 360
     penetrationDamageTypeRequirement:
@@ -261,9 +261,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 180
+    damage: 60
   - type: Tracer
     color: "#00b0ffFF"
     length: 3

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/crossbow_bolts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/crossbow_bolts.yml
@@ -107,7 +107,7 @@
     attackRate: 1
     damage:
       types:
-        Piercing: 4
+        Piercing: 11
     angle: 0
     animation: WeaponArcThrust
     soundHit:
@@ -166,8 +166,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
-        Slash: 15
+        Piercing: 14
+        Slash: 41
 
 - type: entity
   parent: BaseCrossbowBolt
@@ -189,7 +189,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
+        Piercing: 50
     deleteOnCollide: true
   - type: SolutionContainerManager
     solutions:
@@ -239,7 +239,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
+        Piercing: 40
   - type: Construction
     graph: CraftCrossbowBoltGlassShard
     node: CraftCrossbowBoltGlassShard
@@ -270,7 +270,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
+        Piercing: 47
   - type: Construction
     graph: CraftCrossbowBoltPlasmaGlassShard
     node: CraftCrossbowBoltPlasmaGlassShard
@@ -302,8 +302,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
-        Radiation: 5
+        Piercing: 40
+        Radiation: 10
   - type: Construction
     graph: CraftCrossbowBoltUraniumGlassShard
     node: CraftCrossbowBoltUraniumGlassShard
@@ -369,7 +369,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
+        Piercing: 40
     ignoreResistances: true
   - type: Construction
     graph: CraftCrossbowBoltPlasteel
@@ -456,7 +456,7 @@
         Blunt: 10
     deleteOnCollide: true
   - type: StaminaDamageOnCollide
-    damage: 20
+    damage: 105
   - type: EmpOnTrigger
     range: 0.5
     energyConsumption: 2700000
@@ -575,7 +575,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 6
+        Piercing: 10
   - type: TimedDespawn
     lifetime: 0.25
 
@@ -603,6 +603,6 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
+        Piercing: 10
         Slash: 5
         Bloodloss: 5

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/crossbow_bolts.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/crossbow_bolts.yml
@@ -76,7 +76,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 90
+        damage: 30
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -96,7 +96,7 @@
     onlyCollideWhenShot: true
     damage:
       types:
-        Piercing: 75
+        Piercing: 25
 
 - type: entity
   parent: [ BaseBoltProjectile, BaseBoltEmbeddable, BaseBoltLiquidInjector, BaseC1Contraband ]
@@ -107,7 +107,7 @@
     attackRate: 1
     damage:
       types:
-        Piercing: 12
+        Piercing: 4
     angle: 0
     animation: WeaponArcThrust
     soundHit:
@@ -166,8 +166,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
-        Slash: 45
+        Piercing: 5
+        Slash: 15
 
 - type: entity
   parent: BaseCrossbowBolt
@@ -189,7 +189,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 60
+        Piercing: 20
     deleteOnCollide: true
   - type: SolutionContainerManager
     solutions:
@@ -239,7 +239,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 60
+        Piercing: 20
   - type: Construction
     graph: CraftCrossbowBoltGlassShard
     node: CraftCrossbowBoltGlassShard
@@ -270,7 +270,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 60
+        Piercing: 20
   - type: Construction
     graph: CraftCrossbowBoltPlasmaGlassShard
     node: CraftCrossbowBoltPlasmaGlassShard
@@ -302,8 +302,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 45
-        Radiation: 15
+        Piercing: 15
+        Radiation: 5
   - type: Construction
     graph: CraftCrossbowBoltUraniumGlassShard
     node: CraftCrossbowBoltUraniumGlassShard
@@ -337,7 +337,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 45
+        Piercing: 15
     deleteOnCollide: true
   - type: Construction
     graph: CraftCrossbowBoltSyringe
@@ -369,7 +369,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 54
+        Piercing: 18
     ignoreResistances: true
   - type: Construction
     graph: CraftCrossbowBoltPlasteel
@@ -403,7 +403,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 45
+        Piercing: 15
     deleteOnCollide: true
   - type: ExplodeOnTrigger
   - type: Explosive
@@ -452,8 +452,8 @@
   - type: Projectile
     damage:
       types:
-        Shock: 15
-        Blunt: 30
+        Shock: 5
+        Blunt: 10
     deleteOnCollide: true
   - type: StaminaDamageOnCollide
     damage: 20
@@ -501,7 +501,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 30
+        Piercing: 10
     deleteOnCollide: true
   - type: IgniteOnProjectileHit
     fireStacks: 0.5
@@ -541,7 +541,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 15
+        Blunt: 5
     deleteOnCollide: true
   - type: SpawnOnTrigger
     proto: CrossbowBoltShrapnelSpread
@@ -575,7 +575,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
+        Piercing: 6
   - type: TimedDespawn
     lifetime: 0.25
 
@@ -603,6 +603,6 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
-        Slash: 15
-        Bloodloss: 15
+        Piercing: 5
+        Slash: 5
+        Bloodloss: 5

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
@@ -9,7 +9,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 8
+        Heat: 22
 
 # Assault Rifles / Carbines
 - type: entity
@@ -38,7 +38,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 12
+        Heat: 32
 
 # Rifles
 - type: entity
@@ -50,7 +50,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 14
+        Heat: 38
 
 #region Disabler bolts
 - type: entity
@@ -78,12 +78,12 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 2
+        Heat: 0
     soundHit:
       collection: WeakHit
     forceSound: true
   - type: StaminaDamageOnCollide
-    damage: 18
+    damage: 22 # ~5 shots to stun, ~3 to slow
 
 - type: entity
   id: NFBulletDisablerLow
@@ -95,12 +95,12 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 1
+        Heat: 0
     soundHit:
       collection: WeakHit
     forceSound: true
   - type: StaminaDamageOnCollide
-    damage: 14
+    damage: 18 # ~6 shots to stun, ~3 to slow
 
 #region Kinetic bolts
 - type: entity
@@ -113,7 +113,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 10
+        Blunt: 20
         Structural: 30
   - type: Ammo
     muzzleFlash: HitscanEffect
@@ -136,7 +136,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 13
+        Blunt: 25
         Structural: 30
 
 - type: entity
@@ -155,7 +155,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 18
+        Blunt: 30
         Structural: 30
   - type: PointLight
     color: "#ffffff"

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
@@ -9,7 +9,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 24
+        Heat: 8
 
 # Assault Rifles / Carbines
 - type: entity
@@ -38,7 +38,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 36
+        Heat: 12
 
 # Rifles
 - type: entity
@@ -50,7 +50,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 42
+        Heat: 14
 
 #region Disabler bolts
 - type: entity
@@ -78,12 +78,12 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 0
+        Heat: 2
     soundHit:
       collection: WeakHit
     forceSound: true
   - type: StaminaDamageOnCollide
-    damage: 54
+    damage: 18
 
 - type: entity
   id: NFBulletDisablerLow
@@ -95,12 +95,12 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Heat: 0
+        Heat: 1
     soundHit:
       collection: WeakHit
     forceSound: true
   - type: StaminaDamageOnCollide
-    damage: 42
+    damage: 14
 
 #region Kinetic bolts
 - type: entity
@@ -113,8 +113,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 30
-        Structural: 90
+        Blunt: 10
+        Structural: 30
   - type: Ammo
     muzzleFlash: HitscanEffect
   - type: TimedDespawn
@@ -136,8 +136,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 39
-        Structural: 90
+        Blunt: 13
+        Structural: 30
 
 - type: entity
   id: NFBulletKineticHighPower
@@ -155,8 +155,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 54
-        Structural: 90
+        Blunt: 18
+        Structural: 30
   - type: PointLight
     color: "#ffffff"
   - type: MiningGatheringHard

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
@@ -3,7 +3,7 @@
   id: NFRedLightLaser
   damage:
     types:
-      Heat: 8
+      Heat: 21
   muzzleFlash: &lightMuzzleFlash
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -20,7 +20,7 @@
   id: NFRedMediumLaser
   damage:
     types:
-      Heat: 12
+      Heat: 32
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -37,7 +37,7 @@
   id: NFRedHeavyLaser
   damage:
     types:
-      Heat: 14
+      Heat: 37
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -54,7 +54,7 @@
   id: NFRedSpecialLaser
   damage:
     types:
-      Heat: 20
+      Heat: 50
   muzzleFlash: &specialMuzzleFlash
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy2
@@ -71,8 +71,8 @@
   id: NFXrayLaser
   damage:
     types:
-      Heat: 10
-      Radiation: 10
+      Heat: 15
+      Radiation: 25
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray
@@ -89,7 +89,7 @@
   id: NFPulse
   damage:
     types:
-      Heat: 18
+      Heat: 45
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue
@@ -114,14 +114,14 @@
 
 # Shuttle guns
 
-# Whatstone - got a rough value based on 
+# Whatstone - got a rough value based on
 - type: hitscan
   id: NFRedShuttleLaser
   maxLength: 60
   damage:
     types:
-      Heat: 30
-      Structural: 10
+      Heat: 80
+      Structural: 25
   muzzleFlash: *specialMuzzleFlash
   travelFlash: *specialTravelFlash
   impactFlash: *specialImpactFlash

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/hitscan.yml
@@ -3,7 +3,7 @@
   id: NFRedLightLaser
   damage:
     types:
-      Heat: 24
+      Heat: 8
   muzzleFlash: &lightMuzzleFlash
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -20,7 +20,7 @@
   id: NFRedMediumLaser
   damage:
     types:
-      Heat: 36
+      Heat: 12
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -54,7 +54,7 @@
   id: NFRedSpecialLaser
   damage:
     types:
-      Heat: 60
+      Heat: 20
   muzzleFlash: &specialMuzzleFlash
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy2
@@ -71,8 +71,8 @@
   id: NFXrayLaser
   damage:
     types:
-      Heat: 30
-      Radiation: 30
+      Heat: 10
+      Radiation: 10
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray
@@ -89,7 +89,7 @@
   id: NFPulse
   damage:
     types:
-      Heat: 54
+      Heat: 18
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue
@@ -114,14 +114,14 @@
 
 # Shuttle guns
 
-# Whatstone - got a rough value based on
+# Whatstone - got a rough value based on 
 - type: hitscan
   id: NFRedShuttleLaser
   maxLength: 60
   damage:
     types:
-      Heat: 90
-      Structural: 30
+      Heat: 30
+      Structural: 10
   muzzleFlash: *specialMuzzleFlash
   travelFlash: *specialTravelFlash
   impactFlash: *specialImpactFlash

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magic.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magic.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Heat: 2
+        Heat: 5
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
@@ -27,8 +27,8 @@
   - type: Projectile
     damage:
       types:
-        Bloodloss: 3
-        Asphyxiation: 3
+        Bloodloss: 8
+        Asphyxiation: 8
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
@@ -46,8 +46,8 @@
   - type: Projectile
     damage:
       types:
-        Bloodloss: 2
-        Slash: 4
+        Bloodloss: 5
+        Slash: 10
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
@@ -61,7 +61,7 @@
   id: BloodCultLaser
   damage:
     types:
-      Slash: 8
+      Slash: 10
   muzzleFlash:
     sprite: _NF/Effects/bloodcultbeams.rsi
     state: red_lightning
@@ -125,6 +125,6 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Cold: 4
-        Structural: 10
+        Piercing: 11
+        Cold: 11
+        Structural: 27

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magic.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magic.yml
@@ -7,7 +7,7 @@
   - type: Projectile
     damage:
       types:
-        Heat: 6
+        Heat: 2
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
@@ -27,8 +27,8 @@
   - type: Projectile
     damage:
       types:
-        Bloodloss: 9
-        Asphyxiation: 9
+        Bloodloss: 3
+        Asphyxiation: 3
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
@@ -46,8 +46,8 @@
   - type: Projectile
     damage:
       types:
-        Bloodloss: 6
-        Slash: 12
+        Bloodloss: 2
+        Slash: 4
   - type: Sprite
     noRot: false
     sprite: Objects/Weapons/Guns/Projectiles/magic.rsi
@@ -61,7 +61,7 @@
   id: BloodCultLaser
   damage:
     types:
-      Slash: 24
+      Slash: 8
   muzzleFlash:
     sprite: _NF/Effects/bloodcultbeams.rsi
     state: red_lightning
@@ -79,7 +79,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StaminaDamageOnCollide
-    damage: 300
+    damage: 100
   - type: Projectile
     damage:
       types:
@@ -99,7 +99,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StaminaDamageOnCollide
-    damage: 300
+    damage: 100
   - type: Projectile
     damage:
       types:
@@ -125,6 +125,6 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
-        Cold: 12
-        Structural: 30
+        Piercing: 4
+        Cold: 4
+        Structural: 10

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -9,10 +9,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
-        Blunt: 12
+        Piercing: 4
+        Blunt: 4
   - type: StaminaDamageOnCollide
-    damage: 12 # 15 hits to slowdown
+    damage: 4 # 15 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Overpressure
@@ -23,10 +23,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
-        Blunt: 15
+        Piercing: 4
+        Blunt: 5
   - type: StaminaDamageOnCollide
-    damage: 15 # 12 hits to slowdown
+    damage: 5 # 12 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Incendiary
@@ -37,10 +37,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 14.4 # 0.6 * base total dmg
-        Heat: 9.6 # 0.4 * base total dmg
+        Blunt: 4.8 # 0.6 * base total dmg
+        Heat: 3.2 # 0.4 * base total dmg
   - type: StaminaDamageOnCollide
-    damage: 12 # 15 hits to slowdown
+    damage: 4 # 15 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Uranium
@@ -51,10 +51,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 19.8 # 0.6 * (1.4 * base total dmg)
-        Radiation: 13.2 # 0.4 * (1.4 * base total dmg)
+        Blunt: 6.6 # 0.6 * (1.4 * base total dmg)
+        Radiation: 4.4 # 0.4 * (1.4 * base total dmg)
   - type: StaminaDamageOnCollide
-    damage: 12 # 15 hits to slowdown
+    damage: 4 # 15 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Practice
@@ -78,10 +78,10 @@
   - type: Projectile
     damage:
       types:
-        Shock: 12
-        Blunt: 12
+        Shock: 4
+        Blunt: 4
   - type: StaminaDamageOnCollide
-    damage: 12 # 15 hits to slowdown
+    damage: 4 # 15 hits to slowdown
 
 - type: entity
   id: NFBulletPistol35Rubber
@@ -92,9 +92,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 1
   - type: StaminaDamageOnCollide
-    damage: 39 # ~8 hits to stun sounds reasonable
+    damage: 13 # ~8 hits to stun sounds reasonable
 
 #region .45 pistol
 - type: entity
@@ -106,10 +106,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
-        Blunt: 18
+        Piercing: 6
+        Blunt: 6
   - type: StaminaDamageOnCollide
-    damage: 18 # 10 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Overpressure
@@ -120,10 +120,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 18
-        Blunt: 21
+        Piercing: 6
+        Blunt: 7
   - type: StaminaDamageOnCollide
-    damage: 21 # ~9 hits to slowdown
+    damage: 7 # ~9 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Incendiary
@@ -134,10 +134,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 21.6 # 0.6 * base total dmg
-        Heat: 14.4 # 0.4 * base total dmg
+        Blunt: 7.2 # 0.6 * base total dmg
+        Heat: 4.8 # 0.4 * base total dmg
   - type: StaminaDamageOnCollide
-    damage: 18 # 10 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Uranium
@@ -148,10 +148,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 28.8 # 0.6 * (1.4 * base total dmg)
-        Radiation: 19.2 # 0.6 * (1.4 * base total dmg)
+        Blunt: 9.6 # 0.6 * (1.4 * base total dmg)
+        Radiation: 6.4 # 0.6 * (1.4 * base total dmg)
   - type: StaminaDamageOnCollide
-    damage: 18 # 10 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Practice
@@ -162,7 +162,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0.5
+        Blunt: 1
 
 # Frontier
 # .45 pistol
@@ -175,10 +175,10 @@
   - type: Projectile
     damage:
       types:
-        Shock: 18
-        Blunt: 18
+        Shock: 6
+        Blunt: 6
   - type: StaminaDamageOnCollide
-    damage: 18 # 10 hits to slowdown
+    damage: 6 # 10 hits to slowdown
 
 - type: entity
   id: NFBulletPistol45Rubber
@@ -189,6 +189,6 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 2
   - type: StaminaDamageOnCollide
-    damage: 54 # ~6 hits to stun sounds reasonable
+    damage: 18 # ~6 hits to stun sounds reasonable

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -9,10 +9,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Blunt: 4
+        Piercing: 11
+        Blunt: 11
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 15 # 4 hits to slowdown | 5 shots to kill
 
 - type: entity
   id: NFBulletPistol35Overpressure
@@ -23,10 +23,10 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Blunt: 5
+        Piercing: 11
+        Blunt: 14
   - type: StaminaDamageOnCollide
-    damage: 5 # 12 hits to slowdown
+    damage: 16 # 5 hits to slowdown | 4 shots to kill
 
 - type: entity
   id: NFBulletPistol35Incendiary
@@ -37,10 +37,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 4.8 # 0.6 * base total dmg
-        Heat: 3.2 # 0.4 * base total dmg
+        Blunt: 13 # 0.6 * base total dmg
+        Heat: 9 # 0.4 * base total dmg
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 7.5 # 8 hits to slowdown | ~ 10 shots to kill
 
 - type: entity
   id: NFBulletPistol35Uranium
@@ -51,10 +51,10 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 6.6 # 0.6 * (1.4 * base total dmg)
-        Radiation: 4.4 # 0.4 * (1.4 * base total dmg)
+        Blunt: 18 # 0.6 * (1.4 * base total dmg)
+        Radiation: 12 # 0.4 * (1.4 * base total dmg)
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 20 # 3 shots to slow | 4 shots to kill
 
 - type: entity
   id: NFBulletPistol35Practice
@@ -65,7 +65,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0.5
+        Blunt: 0
 
 # Frontier
 # .35 pistol
@@ -78,10 +78,10 @@
   - type: Projectile
     damage:
       types:
-        Shock: 4
-        Blunt: 4
+        Shock: 11
+        Blunt: 11
   - type: StaminaDamageOnCollide
-    damage: 4 # 15 hits to slowdown
+    damage: 15 # 4 hits to slowdown | 5 shots to kill
 
 - type: entity
   id: NFBulletPistol35Rubber
@@ -92,9 +92,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 1
+        Blunt: 0
   - type: StaminaDamageOnCollide
-    damage: 13 # ~8 hits to stun sounds reasonable
+    damage: 22 # ~5 shots to stun, ~3 to slow
 
 #region .45 pistol
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
@@ -11,11 +11,11 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 3
     soundHit:
       path: /Audio/Weapons/Guns/Hits/snap.ogg
   - type: StaminaDamageOnCollide
-    damage: 66 # 5 hits to stun sounds reasonable
+    damage: 22 # 5 hits to stun sounds reasonable
 
 - type: entity
   id: BaseBulletEmp
@@ -353,7 +353,7 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Cold: 12
+        Cold: 4
   - type: TimedDespawn
     lifetime: 3
   - type: ChangeTemperatureOnCollide
@@ -368,7 +368,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 12
+        Heat: 4
   - type: ChangeTemperatureOnCollide
     heat: 50000
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/projectiles.yml
@@ -11,11 +11,11 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
+        Blunt: 0
     soundHit:
       path: /Audio/Weapons/Guns/Hits/snap.ogg
   - type: StaminaDamageOnCollide
-    damage: 22 # 5 hits to stun sounds reasonable
+    damage: 35 # 4 hits to stun sounds reasonable
 
 - type: entity
   id: BaseBulletEmp
@@ -197,7 +197,7 @@
   - type: Projectile
     damage:
       types: # it's for mining hard things, not destroying critters
-        Blunt: 0.5
+        Blunt: 1
         Structural: 1
   - type: TimedDespawn
     lifetime: 1
@@ -353,7 +353,7 @@
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
-        Cold: 4
+        Cold: 11
   - type: TimedDespawn
     lifetime: 3
   - type: ChangeTemperatureOnCollide
@@ -368,7 +368,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 4
+        Heat: 11
   - type: ChangeTemperatureOnCollide
     heat: 50000
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -9,7 +9,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 11
+        Piercing: 30
 
 - type: entity
   id: NFBulletRifle10Practice
@@ -20,7 +20,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 1
+        Piercing: 0
 
 - type: entity
   id: NFBulletRifle10Rubber
@@ -31,9 +31,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 1
+        Piercing: 0
   - type: StaminaDamageOnCollide
-    damage: 10.5 # ~10 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
+    damage: 30 # ~4 hits to stun
 
 #region .20 rifle
 - type: entity
@@ -45,7 +45,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 13
+        Piercing: 35
 
 - type: entity
   id: NFBulletRifle20Overpressure
@@ -56,7 +56,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
+        Piercing: 38
 
 - type: entity
   id: NFBulletRifle20Incendiary
@@ -67,8 +67,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 7.8 # 0.6 * base total dmg
-        Heat: 5.2 # 0.4 * base total dmg
+        Piercing: 21 # 0.6 * base total dmg
+        Heat: 14 # 0.4 * base total dmg
 
 - type: entity
   id: NFBulletRifle20Uranium
@@ -79,8 +79,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10.8 # 0.6 * (1.4 * base total dmg)
-        Radiation: 7.2 # 0.4 * (1.4 * base total dmg)
+        Piercing: 29 # 0.6 * (1.4 * base total dmg)
+        Radiation: 19 # 0.4 * (1.4 * base total dmg)
 
 - type: entity
   id: NFBulletRifle20Practice
@@ -91,7 +91,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
+        Piercing: 0
 
 - type: entity
   id: NFBulletRifle20Rubber
@@ -102,9 +102,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
+        Piercing: 0
   - type: StaminaDamageOnCollide
-    damage: 12 # ~9 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
+    damage: 35 # ~3 hits to stun
 
 #region .25 rifle
 - type: entity
@@ -116,7 +116,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 14
+        Piercing: 38
 
 - type: entity
   id: NFBulletRifle25Overpressure
@@ -127,7 +127,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 43
 
 - type: entity
   id: NFBulletRifle25Incendiary
@@ -138,8 +138,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 8.4 # 0.6 * base total dmg
-        Heat: 5.6 # 0.4 * base total dmg
+        Piercing: 23 # 0.6 * base total dmg
+        Heat: 15 # 0.4 * base total dmg
 
 - type: entity
   id: NFBulletRifle25Uranium
@@ -150,8 +150,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 11.4 # 0.6 * (1.4 * base total dmg)
-        Radiation: 7.6 # 0.4 * (1.4 * base total dmg)
+        Piercing: 23 # 0.6 * (1.4 * base total dmg)
+        Radiation: 15 # 0.4 * (1.4 * base total dmg)
 
 - type: entity
   id: NFBulletRifle25Practice
@@ -162,7 +162,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
+        Piercing: 0
 
 - type: entity
   id: NFBulletRifle25Rubber
@@ -173,9 +173,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
+        Piercing: 0
   - type: StaminaDamageOnCollide
-    damage: 12 # ~9 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
+    damage: 38 # ~3 hits to stun
 
 #region .30 rifle
 - type: entity
@@ -187,7 +187,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
+        Piercing: 41
 
 - type: entity
   id: NFBulletRifle30Overpressure
@@ -198,7 +198,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 46
 
 - type: entity
   id: NFBulletRifle30Incendiary
@@ -209,8 +209,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 9
-        Heat: 6
+        Piercing: 25
+        Heat: 16
 
 - type: entity
   id: NFBulletRifle30Uranium
@@ -221,8 +221,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12.6
-        Radiation: 8.4
+        Piercing: 25
+        Radiation: 16
 
 - type: entity
   id: NFBulletRifle30Practice
@@ -233,7 +233,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
+        Piercing: 0
 
 - type: entity
   id: NFBulletRifle30Rubber
@@ -244,9 +244,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
+        Piercing: 0
   - type: StaminaDamageOnCollide
-    damage: 13 # ~8 hits to stun sounds reasonable
+    damage: 41 # ~3 hits to stun
 
 #region .60 rifle
 - type: entity
@@ -258,7 +258,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 95
         Structural: 200
     penetrationThreshold: 360
     penetrationDamageTypeRequirement:
@@ -273,6 +273,6 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10
+        Blunt: 0
   - type: StaminaDamageOnCollide
-    damage: 70
+    damage: 95 # ~2 hits to stun

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -9,7 +9,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 33
+        Piercing: 11
 
 - type: entity
   id: NFBulletRifle10Practice
@@ -20,7 +20,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0.5
+        Piercing: 1
 
 - type: entity
   id: NFBulletRifle10Rubber
@@ -31,9 +31,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0.5
+        Piercing: 1
   - type: StaminaDamageOnCollide
-    damage: 31.5 # ~10 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
+    damage: 10.5 # ~10 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
 
 #region .20 rifle
 - type: entity
@@ -45,7 +45,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 39
+        Piercing: 13
 
 - type: entity
   id: NFBulletRifle20Overpressure
@@ -56,7 +56,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 42
+        Piercing: 14
 
 - type: entity
   id: NFBulletRifle20Incendiary
@@ -67,8 +67,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 23.4 # 0.6 * base total dmg
-        Heat: 15.6 # 0.4 * base total dmg
+        Piercing: 7.8 # 0.6 * base total dmg
+        Heat: 5.2 # 0.4 * base total dmg
 
 - type: entity
   id: NFBulletRifle20Uranium
@@ -79,8 +79,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 32.4 # 0.6 * (1.4 * base total dmg)
-        Radiation: 21.6 # 0.4 * (1.4 * base total dmg)
+        Piercing: 10.8 # 0.6 * (1.4 * base total dmg)
+        Radiation: 7.2 # 0.4 * (1.4 * base total dmg)
 
 - type: entity
   id: NFBulletRifle20Practice
@@ -91,7 +91,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0.5
+        Piercing: 2
 
 - type: entity
   id: NFBulletRifle20Rubber
@@ -102,9 +102,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0
+        Piercing: 2
   - type: StaminaDamageOnCollide
-    damage: 36 # ~9 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
+    damage: 12 # ~9 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
 
 #region .25 rifle
 - type: entity
@@ -116,7 +116,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 42
+        Piercing: 14
 
 - type: entity
   id: NFBulletRifle25Overpressure
@@ -127,7 +127,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 48
+        Piercing: 16
 
 - type: entity
   id: NFBulletRifle25Incendiary
@@ -138,8 +138,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25.2 # 0.6 * base total dmg
-        Heat: 16.8 # 0.4 * base total dmg
+        Piercing: 8.4 # 0.6 * base total dmg
+        Heat: 5.6 # 0.4 * base total dmg
 
 - type: entity
   id: NFBulletRifle25Uranium
@@ -150,8 +150,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 34.2 # 0.6 * (1.4 * base total dmg)
-        Radiation: 22.8 # 0.4 * (1.4 * base total dmg)
+        Piercing: 11.4 # 0.6 * (1.4 * base total dmg)
+        Radiation: 7.6 # 0.4 * (1.4 * base total dmg)
 
 - type: entity
   id: NFBulletRifle25Practice
@@ -162,7 +162,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0.5
+        Piercing: 2
 
 - type: entity
   id: NFBulletRifle25Rubber
@@ -173,9 +173,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0
+        Piercing: 2
   - type: StaminaDamageOnCollide
-    damage: 36 # ~9 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
+    damage: 12 # ~9 hits to stun sounds reasonable, less effective than pistol because rifle round is smaller in size
 
 #region .30 rifle
 - type: entity
@@ -187,7 +187,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 45
+        Piercing: 15
 
 - type: entity
   id: NFBulletRifle30Overpressure
@@ -198,7 +198,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 51
+        Piercing: 17
 
 - type: entity
   id: NFBulletRifle30Incendiary
@@ -209,8 +209,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 27
-        Heat: 18
+        Piercing: 9
+        Heat: 6
 
 - type: entity
   id: NFBulletRifle30Uranium
@@ -221,8 +221,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 37.8
-        Radiation: 25.2
+        Piercing: 12.6
+        Radiation: 8.4
 
 - type: entity
   id: NFBulletRifle30Practice
@@ -233,7 +233,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0.5
+        Piercing: 2
 
 - type: entity
   id: NFBulletRifle30Rubber
@@ -244,9 +244,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 0
+        Piercing: 2
   - type: StaminaDamageOnCollide
-    damage: 39 # ~8 hits to stun sounds reasonable
+    damage: 13 # ~8 hits to stun sounds reasonable
 
 #region .60 rifle
 - type: entity
@@ -258,7 +258,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 105
+        Piercing: 35
         Structural: 200
     penetrationThreshold: 360
     penetrationDamageTypeRequirement:
@@ -273,6 +273,6 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 210 # one hit to stun LOL
+    damage: 70

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -8,7 +8,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
+        Piercing: 11
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -19,7 +19,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
+        Piercing: 13
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -30,8 +30,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2.4
-        Heat: 1.6
+        Blunt: 7
+        Heat: 4
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -42,7 +42,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0.1
+        Blunt: 0
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -53,8 +53,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 3.5
-        Radiation: 3.5
+        Piercing: 7
+        Radiation: 7
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -73,8 +73,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 2
-        Slash: 2
+        Piercing: 5
+        Slash: 4
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -85,7 +85,7 @@
   - type: Projectile
     damage:
       types:
-        Slash: 3.5
+        Slash: 5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -96,8 +96,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-        Structural: 5
+        Piercing: 11
+        Structural: 14
 
 #region PelletsSpread
 - type: entity
@@ -106,7 +106,7 @@
   components:
   - type: ProjectileSpread
     count: 7 # eight(?) total, includes the spread as a bullet
-    spread: 10
+    spread: 25
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -182,8 +182,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 20
-        Blunt: 5
+        Piercing: 54
+        Blunt: 14
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -194,9 +194,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10
+        Blunt: 0
   - type: StaminaDamageOnCollide
-    damage: 30 # 4 hits to stun
+    damage: 68 # 2 hits to stun
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -235,7 +235,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 1
+        Blunt: 0
   - type: SolutionContainerManager
     solutions:
       ammo:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -8,7 +8,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
+        Piercing: 4
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -19,7 +19,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15
+        Piercing: 5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -30,8 +30,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 7.2
-        Heat: 4.8
+        Blunt: 2.4
+        Heat: 1.6
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -53,8 +53,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10.5
-        Radiation: 10.5
+        Piercing: 3.5
+        Radiation: 3.5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -73,8 +73,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 6
-        Slash: 6
+        Piercing: 2
+        Slash: 2
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -85,7 +85,7 @@
   - type: Projectile
     damage:
       types:
-        Slash: 10.5
+        Slash: 3.5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -96,8 +96,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 12
-        Structural: 15
+        Piercing: 4
+        Structural: 5
 
 #region PelletsSpread
 - type: entity
@@ -182,8 +182,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 60
-        Blunt: 15
+        Piercing: 20
+        Blunt: 5
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -194,9 +194,9 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 90 # 4 hits to stun
+    damage: 30 # 4 hits to stun
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -235,7 +235,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 0
+        Blunt: 1
   - type: SolutionContainerManager
     solutions:
       ammo:


### PR DESCRIPTION
The damage of all calibers has been buffed. varies between 2.7(5)x and 1.2x designed for a htk/s of ~2-6 and a ttk of ~2 seconds.

Shotguns have received an accuracy penalty to offset their otherwise high damage due to a lack of falloff. 

Exped mobs have had all of their special ammo flattened to base; no more incendiary/uranium/overpressure ammo just cause. If they are still too lethal, I will give them custom ammunition that does less than THAT to give average players the edge. If it's too weak I will readd their custom ammunition. Requires further testing.

Some Exped mobs received recoil and others have had it increased.