### PR TITLE
Damage falloff

### DIFF
--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -1,7 +1,9 @@
+using System.Numerics;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Projectiles;
@@ -98,4 +100,31 @@ public sealed partial class ProjectileComponent : Component
     /// </summary>
     [DataField]
     public FixedPoint2 PenetrationAmount = FixedPoint2.Zero;
+
+    /// <summary>
+    /// The global coords of the projectile when it was fired.
+    /// This is used to calculate range falloff, even if it leaves the grid
+    /// </summary>
+    [DataField]
+    public Vector2 OriginPoint;
+
+    /// <summary>
+    /// The max effective range of the projectile.
+    /// after this length it will start to lose damage.
+    /// </summary>
+    [DataField]
+    public float FalloffStartMeters = 15f;
+
+    /// <summary>
+    /// percent of damage to lose per meter after max effective range
+    /// </summary>
+    [DataField]
+    public float FalloffPercentPerMeter = 0f;
+
+    /// <summary>
+    /// The minimum damage this projectile can do due to range falloff.
+    /// </summary>
+    [DataField]
+    public DamageSpecifier FalloffMinDamage = new();
+
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -445,6 +445,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         var shooter = user ?? gunUid;
         if (shooter != null)
             Projectiles.SetShooter(uid, projectile, shooter.Value);
+        projectile.OriginPoint = TransformSystem.GetWorldPosition(uid);
 
         TransformSystem.SetWorldRotation(uid, direction.ToWorldAngle() + projectile.Angle);
     }

--- a/Resources/Prototypes/Entities/Debugging/debug_sweps.yml
+++ b/Resources/Prototypes/Entities/Debugging/debug_sweps.yml
@@ -84,6 +84,68 @@
     proto: BulletDebug
 
 - type: entity
+  name: bang, 100dmg, falloff 10%
+  parent: WeaponPistolDebug
+  id: WeaponPistolDebug100Dmg10Falloff
+  description: pro
+  suffix: DEBUG
+  components:
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: MagazinePistolDebug100Dmg10Falloff
+        insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - Debug
+      gun_chamber:
+        name: Chamber
+        startingItem: CartridgeDebug100Dmg10Falloff
+        priority: 1
+        whitelist:
+          tags:
+            - CartridgePistol
+
+- type: entity
+  id: MagazinePistolDebug100Dmg10Falloff
+  name: bang, 100dmg, falloff 10% mag
+  parent: MagazinePistolDebug
+  suffix: DEBUG
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeDebug100Dmg10Falloff
+    capacity: 1000
+
+- type: entity
+  id: BulletDebug100Dmg10Falloff
+  name: bang, 100dmg, falloff 10% bullet
+  parent: BulletDebug
+  categories: [ Debug, HideSpawnMenu ]
+  suffix: DEBUG
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 100
+    falloffStartMeters: 2
+    falloffPercentPerMeter: 10
+    falloffMinDamage:
+      types:
+          Blunt: 10
+
+- type: entity
+  id: CartridgeDebug100Dmg10Falloff
+  name: bang, 100dmg, falloff 10% cartridge
+  parent: CartridgeDebug
+  suffix: DEBUG
+  components:
+  - type: CartridgeAmmo
+    proto: BulletDebug100Dmg10Falloff
+
+- type: entity
   name: bang stick gibber
   parent: BaseItem
   id: MeleeDebugGib


### PR DESCRIPTION
Adds support for a certain bunny to give projectiles damage falloff!

HOW TO DO IT:

Find something with `type: Projectile`
You can use these:
    falloffStartMeters: 2 // The meters out where damage starts falling off
    falloffPercentPerMeter: 10 // percent damage taken away per meter. this is compound, so 3 meters is (0.9 * 0.9 * 0.9...)
    falloffMinDamage: // this is a DamageSpecifier, done just like `damage`. If the total damage falls below this, it'll just use this instead
      types:
          Blunt: 10