### PR TITLE
Edison maintenance adjustments and buyable tesla coils

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -107,7 +107,7 @@
 
 - type: cargoProduct
   id: EngineTeslaCoil
-  abstract: true # Frontier
+  #abstract: true # Frontier - Coyote edit
   icon:
     sprite: Structures/Power/Generation/Tesla/coil.rsi
     state: coil

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -61,7 +61,11 @@
     radiationReactiveGases:
       - reactantPrototype: Plasma
         powerGenerationEfficiency: 1
-        reactantBreakdownRate: 0.0001
+        reactantBreakdownRate: 0.000000325
+        # Coyote edit - Adjusted to have a halflife of 8 hours. Math is as follows with current values: 2 moles, 7.4 rads, 0.0001 reactantbreakdown rate (old value)
+        # f(t)=2e^(-7.4*0.0001*t)
+        # 0.0001 only has a half life of 15 minutes. Readjusting to 8 hours.
+        # reactantBreakdownRate = ln(2)/(7.4*8*60*60) = 0.000000325
   - type: RadiationReceiver
   - type: PowerSupplier
   - type: Anchorable

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -66,6 +66,9 @@
     hitProbability: 0.5
     lightningResistance: 10
     lightningExplode: false
+    damageFromLightning: 0.03125
+    # Coyote edit - 1 strike every 2 seconds without mini balls. 6 coils in edison. Repair every 24 hours. Health is 225.
+    # 225 / ((24 * 60 * 60) / (2 * 6))
   - type: PowerNetworkBattery
     maxSupply: 1000000
     supplyRampTolerance: 1000000


### PR DESCRIPTION
## About the PR
Adjust maintenance requirement for both Tesla and singularity.
The tesla requires maintenance roughly every 24 hours with 6 coils and no mini balls. (Was 45 minutes before they break)
The half life of the plasma tanks in the radiation collectors is 8 hours. Basically after 8 hours, it will have consumed half the moles and produce half as much power. (was 15 minutes before rad collectors reached half life)

The math is detailed as comments in the code, allowing for much easier adjustments if we want to tweak to different hour thresholds and so on. 

Additionally. Tesla coils can now be bought from cargo in case they do break or Edison wants to beef up their maintenance timer.

My only concern with this PR is that I have no clue how far low the numbers can go in C# or if they are limits or roundings somewhere in the code which could mess with this math

