### PR TITLE
IPCs can heal caustic damage with cable coils

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -46,6 +46,7 @@
         Heat: -7
         Shock: -7
         Cold: -3
+        Caustic: -3 # Corrosion is far more difficult to fix if its not just an oxide layer from burning hence -3
         Structural: -25
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.


### PR DESCRIPTION
Title.

## About the PR
Currently IPCs can only heal caustic damage (i.e. when doused with acid) by being hit by <s> the Proselyte from Mental Omega</s> somebody with a proselyte/faith implant with a bible. This seems like an oversight to me.

Now caustic damage can be healed in a way organics can heal caustic wounds. Organics apply ointment. Synthetics apply cables.

## Why / Balance
Caustic damage already needs toppings. IPCs racking up caustic damage have to get to a priest of Ratvar to fix them currently.
This makes it easier should they somehow get caustic damage (and kinda necessary once and when I get around trying to port fun weapons like the thalaron radiation rifle "Dissolver" from Soj.

## Technical details
It adds another damage type healed by cables that ointments usually fix on organics.

## How to test
Start server with change implemented. Search 4 hours for the one tangible source of caustic damage. Get caustic damage. Heal caustic damage with cable.

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Shouldnt break a thing since it just adds caustic healing to cables for IPCs/synthetics

**Changelog**

<!--
:cl:
- fix: Cables now heal caustic damage for IPCs!
-->
