### PR TITLE
Fixes wrong label on vulpkanin chest.

### DIFF
--- a/Resources/Locale/en-US/_Floof/anthro.ftl
+++ b/Resources/Locale/en-US/_Floof/anthro.ftl
@@ -1060,7 +1060,7 @@ marking-SnoutLCanidStripe = Husky Snout L
 
 marking-SpeciesAdaptorVulpkaninHeadMale    = Base Sprite - Vulpkanin Head (Male)
 marking-SpeciesAdaptorVulpkaninHeadFemale  = Base Sprite - Vulpkanin Head (Female)
-marking-SpeciesAdaptorVulpkaninTorsoMale   = Base Sprite - Vulpkanin Chest (Female)
+marking-SpeciesAdaptorVulpkaninTorsoMale   = Base Sprite - Vulpkanin Chest (Male)
 marking-SpeciesAdaptorVulpkaninTorsoFemale = Base Sprite - Vulpkanin Chest (Female)
 marking-SpeciesAdaptorVulpkaninLArm        = Base Sprite - Vulpkanin Left Arm
 marking-SpeciesAdaptorVulpkaninLHand       = Base Sprite - Vulpkanin Left Hand


### PR DESCRIPTION
Currently there are two chests labelled female. The female one and the male one. This fixes it.

## About the PR
It fixes a UI error

## Why / Balance
Guessing bad

## Technical details
Fixes UI issue

## How to test
Load, make any species, add vulpkanin understructure, see its now male and female

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Shouldnt break stuff.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: UI bug with vulpkanin chest
-->
