### PR TITLE
Makes radiation collectors buyable and raises the price

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -69,7 +69,7 @@
     sprite: Structures/Power/Generation/Singularity/collector.rsi
     state: ca_on
   product: CrateEngineeringSingularityCollector
-  cost: 10000 # Coyote Edit - smallish money sink as those essentially require a setup to generate power from various radiation sources - Requires more setup and occassional refill with plasma
+  cost: 24000 # Coyote Edit - smallish money sink as those essentially require a setup to generate power from various radiation sources - Requires more setup and occassional refill with plasma
   category: cargoproduct-category-name-engineering
   group: market
 


### PR DESCRIPTION

## About the PR
There are a couple very interesting setups you can do with radiation collectors for power generation. Nothing beating an RTG or a DK gen with max upgrades and a capacitor bank but its quite an interesting gimmick. This is especially of note for Sci Ships and Edison. 

## Why / Balance
I kinda not want to constantly have a growing RTG tumor, capacitor bank tumor or solar tumor on my ship and think a dedicated rad box with rad collectors surrounded by plasma glass around a radiation source could be an interesting albeit probably somewhat inefficient alternative. Rule of cool though.

## Technical details
It reenables rad collector purchase and makes them available from cargo for a gimmick

## How to test
Apply changes, move to cargo buy collectors for 24k a pop.

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Shouldn't break anything, it just reenables rad collectors

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Rad collectors can be bought from cargo for 10k
-->
