### PR TITLE
Edison map additions

### DIFF
--- a/Resources/Maps/_NF/POI/edison.yml
+++ b/Resources/Maps/_NF/POI/edison.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.1.0
   forkId: ""
   forkVersion: ""
-  time: 06/20/2025 23:04:02
-  entityCount: 4418
+  time: 10/15/2025 16:09:23
+  entityCount: 4435
 maps: []
 grids:
 - 2
@@ -38,6 +38,7 @@ entities:
   - uid: 2
     components:
     - type: MetaData
+      name: Edison
     - type: Transform
       parent: invalid
     - type: MapGrid
@@ -154,7 +155,7 @@ entities:
     - type: OccluderTree
     - type: SpreaderGrid
     - type: Shuttle
-      dampingModifier: 0.25
+      dampingModifier: 2
     - type: GridPathfinding
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
@@ -3568,6 +3569,18 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 4272
+- proto: AmeJar
+  entities:
+  - uid: 4415
+    components:
+    - type: Transform
+      pos: -1.8743614,38.248528
+      parent: 2
+  - uid: 4416
+    components:
+    - type: Transform
+      pos: -1.5931114,38.248528
+      parent: 2
 - proto: AntiMatterFabricator
   entities:
   - uid: 519
@@ -7715,6 +7728,11 @@ entities:
     - type: Transform
       pos: -2.4444127,37.622223
       parent: 2
+  - uid: 4413
+    components:
+    - type: Transform
+      pos: -2.2493615,37.576653
+      parent: 2
 - proto: CableHV
   entities:
   - uid: 347
@@ -9024,6 +9042,11 @@ entities:
     - type: Transform
       pos: -2.4912877,37.903473
       parent: 2
+  - uid: 4412
+    components:
+    - type: Transform
+      pos: -2.2181115,37.857903
+      parent: 2
 - proto: CableMV
   entities:
   - uid: 358
@@ -10322,6 +10345,11 @@ entities:
     components:
     - type: Transform
       pos: -2.4131627,37.309723
+      parent: 2
+  - uid: 4414
+    components:
+    - type: Transform
+      pos: -2.2649865,37.279778
       parent: 2
 - proto: CableTerminal
   entities:
@@ -11886,6 +11914,20 @@ entities:
     components:
     - type: Transform
       pos: -2.5,22.5
+      parent: 2
+- proto: ComputerShipyard
+  entities:
+  - uid: 4417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 4418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-5.5
       parent: 2
 - proto: ComputerSolarControl
   entities:
@@ -22642,6 +22684,13 @@ entities:
     - type: Transform
       pos: 5.5,41.5
       parent: 2
+- proto: PaperBin20
+  entities:
+  - uid: 3041
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 2
 - proto: PartRodMetal
   entities:
   - uid: 3757
@@ -22653,6 +22702,23 @@ entities:
     components:
     - type: Transform
       pos: -2.3975377,38.356598
+      parent: 2
+  - uid: 3812
+    components:
+    - type: Transform
+      pos: -2.3743615,38.686028
+      parent: 2
+  - uid: 3887
+    components:
+    - type: Transform
+      pos: -2.7181115,38.826653
+      parent: 2
+- proto: Pen
+  entities:
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: 5.3085437,7.2154202
       parent: 2
 - proto: PlaqueAtmos
   entities:
@@ -24882,19 +24948,29 @@ entities:
     - type: Transform
       pos: -1.5,13.5
       parent: 2
-- proto: SellOnlyMothershipComputer
+- proto: SheetGlass
   entities:
-  - uid: 1082
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 2
   - uid: 3752
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-5.5
+      pos: -2.7181115,39.404778
+      parent: 2
+  - uid: 3810
+    components:
+    - type: Transform
+      pos: -2.3118615,39.436028
+      parent: 2
+- proto: SheetSteel
+  entities:
+  - uid: 3610
+    components:
+    - type: Transform
+      pos: -2.6868615,39.686028
+      parent: 2
+  - uid: 3612
+    components:
+    - type: Transform
+      pos: -2.3587365,39.670403
       parent: 2
 - proto: ShuttersRadiationOpen
   entities:
@@ -25550,6 +25626,25 @@ entities:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
+- proto: SprayPainter
+  entities:
+  - uid: 3052
+    components:
+    - type: Transform
+      pos: -6.5188866,11.625724
+      parent: 2
+- proto: SprayPainterAmmo
+  entities:
+  - uid: 3058
+    components:
+    - type: Transform
+      pos: -5.8313866,11.766349
+      parent: 2
+  - uid: 3607
+    components:
+    - type: Transform
+      pos: -5.8157616,11.281974
+      parent: 2
 - proto: StationMap
   entities:
   - uid: 4044
@@ -26158,6 +26253,13 @@ entities:
     components:
     - type: Transform
       pos: 10.5,37.5
+      parent: 2
+- proto: VendingMachineTankDispenserEVAPOI
+  entities:
+  - uid: 3046
+    components:
+    - type: Transform
+      pos: -6.5,12.5
       parent: 2
 - proto: VendingMachineVendomatPOI
   entities:

--- a/Resources/Prototypes/_NF/PointsOfInterest/edison.yml
+++ b/Resources/Prototypes/_NF/PointsOfInterest/edison.yml
@@ -23,6 +23,9 @@
   - type: SolarPoweredGrid
     trackOnInit: true
     doNotCull: true
+  - type: StationTransit
+    routes:
+      SpawnPoints: 40
 
 - type: gameMap
   id: Edison


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Buses now arrive at Edison. Paperbin added. Sell console was replaced with a proper shipyard console. A painter tool near atmos was added. 60 more steel, glass and rods were added to the particle accelerator room. Additionally, two AME canisters and a cable coil of each extra. Lastly, a tank dispenser was added next to the flatpack vendor.

## Why / Balance
I have been playing Edison for a while and I noticed some reoccurring issues with the current map and those were simply that once you have used up your initial resources, you were kinda stuck doing nothing. No bus, no way to move anywhere except for hoping some kind soul gives you a ride to Nash. The gameplay loop of Edison shows that Edison is very much reliant on external supplies which will sadly never or rarely come from other players unless you wish to pay 35 creds per sheet of steel (Yes I had that deal suggested to me). And Edison is stupidly steel hungry, we are talking 1000 sheets of steel minimum. So that is why I think them having a proper shipyard console is good.

Otherwise the extra starting materials will allow people to have 2 projects running at the same time instead of just 1 player doing 1 project while the others are stuck with basically nothing or doing mining. 

One weird thing I noticed is that in the commit change the dampingmodifier was changed. I did not touch that var, I have no clue what it does but it did it automatically. 
