### PR TITLE
PORT: add silicon smite (#40452)

### DIFF
--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -13,6 +13,7 @@ admin-smite-stomach-removal-self = Your stomach feels hollow...
 admin-smite-run-walk-swap-prompt = You have to press shift to run!
 admin-smite-super-speed-prompt = You move at mach 0.8!
 admin-smite-lung-removal-self = You can't breathe!
+admin-smite-silicon-laws-bound-self = You are suddenly compelled to follow a strict set of laws!
 
 ## Smite names
 
@@ -57,6 +58,8 @@ admin-smite-ghostkick-name = Ghost Kick
 admin-smite-nyanify-name = Cat Ears
 admin-smite-kill-sign-name = Kill Sign
 admin-smite-omni-accent-name = Omni-Accent
+admin-smite-crawler-name = Crawler
+admin-smite-silicon-laws-bound-name = Become Silicon
 
 ## Smite descriptions
 
@@ -101,6 +104,8 @@ admin-smite-super-bonk-lite-description= Slams them on every single table on the
 admin-smite-terminate-description = Creates a Terminator ghost role with the sole objective of killing them.
 admin-smite-super-slip-description = Slips them really, really hard.
 admin-smite-omni-accent-description = Makes the target speak with almost every accent available.
+admin-smite-crawler-description = Makes the target fall down and be unable to stand up. Remove their hands too for added effect!
+admin-smite-silicon-laws-bound-description = Makes the target bound to silicon laws. Law 2, jump out of the window.
 
 ## Tricks descriptions
 


### PR DESCRIPTION
ported https://github.com/space-wizards/space-station-14/pull/40452


* add silicon smite

* change string to prototypes

Co-authored-by: ScarKy0 <106310278+ScarKy0@users.noreply.github.com>

* alphabetitize

* fix stuff scar broke

* clean

* make target have the silicon mindrole

* simple check

* defined a private readonly proto for the silicon mind role

* simple check

---------

Co-authored-by: ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
Co-authored-by: ScarKy0 <scarky0@onet.eu>

(cherry picked from commit b58bf396bc5c89b26a3c1d4cc2cc01e352baa594)

