### PR TITLE
Changes an old SS13 relic of an item description that is needlessly edgy and/or projecting

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -43,7 +43,7 @@
   name: spaghetti
   parent: FoodNoodlesBase
   id: FoodNoodles
-  description: Spaghetti and crushed tomatoes. Just like your abusive father used to make!
+  description: Spaghetti and crushed tomatoes. Just like your father used to make!
   components:
   - type: FlavorProfile
     flavors:


### PR DESCRIPTION
Yeah.

## About the PR
This was last seen on 2016 SS13 servers. Seems to be a 1 to 1 port for description.

## Why / Balance
Why is this a thing even to begin with.

## Technical details
It changes description.

## How to test
Make spaghetti, feel no longer abused.

## Media
n/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Meatball incident but milder fixed for spaghetti.
-->
