### PR TITLE
Allows Slimes to Eat (almost) Everything & A Special Moth Treat

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -14,8 +14,7 @@
        - ClothMade
        - Paper
       # - Pill
-      components:
-      - MothFood
+    - type: MothFood
       # End Frontier: general moth digestion
     - type: Metabolizer
       maxReagents: 3

--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -10,9 +10,7 @@
        - ClothMade
        - Paper
       # - Pill
-    components:
-      - MothFood
-      # End Frontier: general moth digestion
+  - type: MothFood
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -14,8 +14,7 @@
        - ClothMade
        - Paper
       # - Pill
-      components:
-      - MothFood
+    - type: MothFood
       # End Frontier: general moth digestion
     - type: Metabolizer
       maxReagents: 6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds Animal, Goblin & Moth foods to accepted things slimepeople can eat.
Adds Animal, Goblin & Moth foods to accepted things simplemob slimes can eat.
Allows slimes to eat ClothMade items (e.g jumpsuits) and paper.
Allows moths to once more, eat ClothMade items (e.g jumpsuits) and paper. 

What this means overall, is that slimepeople can now eat any foodstuff, if a species can eat it, so can slimepeople! 
Moths can also have a little treat.


**Changelog**
:cl:
- add: Added ability for AI slimes to eat everything that animals, goblins and moths can.
- add: Added ability for slimepeople to eat everything that animals, goblins and moths can.
- tweak: Added back ability for Moths to eat certain clothing and paper.