### PR TITLE
Increase mail teleport time

### DIFF
--- a/Content.Server/_NF/Mail/Components/SectorMailComponent.cs
+++ b/Content.Server/_NF/Mail/Components/SectorMailComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class SectorMailComponent : Component // Frontier: Station
     public float Accumulator = 1000f;
 
     [DataField]
-    public TimeSpan TeleportInterval = TimeSpan.FromMinutes(5);
+    public TimeSpan TeleportInterval = TimeSpan.FromMinutes(10);
 
     [DataField]
     public TimeSpan TrashTime = TimeSpan.FromMinutes(60); // Frontier: Trash mail after 30 minutes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This doubles the time for mail to teleport in to the mail teleporter from 5 minutes to 10.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

We get way too much mail right now. Assuming someone is manning the teleporter (pulling mail off consistently) - if there's 40 valid mail targets we'd get 120 pieces of mail in an hour (10 every 5 minutes). This will halve to 60, which is probably still a lot but should be more manageable.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Doubled the times it takes for mail to teleport in