### PR TITLE
Disable some hostile ghost roles

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_aberrant_flesh.yml
@@ -381,16 +381,16 @@
         Slash: 12
         Structural: 30
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-aberrant-flesh-horror-dungeon-name
-    description: ghost-role-information-aberrant-flesh-horror-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-aberrant-flesh-horror-dungeon-name
+    # description: ghost-role-information-aberrant-flesh-horror-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   - type: ActionGun
     action: ActionBoneSpike
     gunProto: BoneSpikeGun

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_argocyte.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_argocyte.yml
@@ -552,16 +552,16 @@
     - id: FoodMeatXeno
       amount: 12
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-leviathing-dungeon-name
-    description: ghost-role-information-leviathing-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-leviathing-dungeon-name
+    # description: ghost-role-information-leviathing-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   - type: ActionGrant
     actions:
     - ActionLeviathingSpawn

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_carp.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_carp.yml
@@ -339,11 +339,11 @@
   id: NFMobDragonDungeon
   suffix: Dungeon, Frontier
   components:
-  - type: GhostRole
-    description: ghost-role-information-space-dragon-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
+  # - type: GhostRole # CS - disable ghost role
+    # description: ghost-role-information-space-dragon-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
   - type: SlowOnDamage
     speedModifierThresholds:
       100: 0.7

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_dinosaurs.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_dinosaurs.yml
@@ -491,16 +491,16 @@
         Piercing: 10
         Structural: 20
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-t-rex-dungeon-name
-    description: ghost-role-information-t-rex-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-t-rex-dungeon-name
+    # description: ghost-role-information-t-rex-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   - type: ActionGun
     action: ActionTRexRoar
     gunProto: TRexRoarGun

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_explorers.yml
@@ -570,16 +570,16 @@
         variation: 0.250
         volume: -10
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-explorer-captain-dungeon-name
-    description: ghost-role-information-explorer-captain-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-explorer-captain-dungeon-name
+    # description: ghost-role-information-explorer-captain-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   - type: ActionGun
     action: ActionSeismicCharge
     gunProto: SeismicChargeGun

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_xeno.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_expeditions_xeno.yml
@@ -24,19 +24,19 @@
   components:
   - type: ReplacementAccent
     accent: xeno
-  - type: GhostRole
-    prob: 1
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # prob: 1
+    # allowMovement: true
+    # allowSpeech: true
+    # makeSentient: true
+    # name: ghost-role-information-xeno-name
+    # description: ghost-role-information-xeno-description
+    # rules: ghost-role-information-xeno-rules
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+    # raffle:
+      # settings: default
+  # - type: GhostTakeoverAvailable
 
 - type: entity
   parent: [MobStaminaFodder, MobMovementSpeedModifierMelee, NFMobSimpleHostileBase, MobXenoRavager]

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_mercenaries.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_mercenaries.yml
@@ -529,16 +529,16 @@
     maxOffset: 10
     pvsIncrease: 1
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-mercenary-captain-dungeon-name
-    description: ghost-role-information-mercenary-captain-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-mercenary-captain-dungeon-name
+    # description: ghost-role-information-mercenary-captain-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   - type: ActionGun
     action: ActionSideArmFan
     gunProto: GunSideArmFan

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_punkganger.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_punkganger.yml
@@ -225,16 +225,16 @@
     soundGunshot: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: Jittering
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-punk-boss-dungeon-name
-    description: ghost-role-information-punk-boss-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-punk-boss-dungeon-name
+    # description: ghost-role-information-punk-boss-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   - type: ActionGun
     action: ActionThrowPartyNade
     gunProto: PartyNadeGun

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_rogue_ai.yml
@@ -1028,16 +1028,16 @@
     energy: 2.5
     color: "#47f8ff"
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-guardian-unit-dungeon-name
-    description: ghost-role-information-one-star-unit-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-guardian-unit-dungeon-name
+    # description: ghost-role-information-one-star-unit-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   # Radar
   - type: UserInterface
     interfaces:
@@ -1105,16 +1105,16 @@
     footstepSoundCollection:
       path: /Audio/Mecha/sound_mecha_powerloader_step.ogg
   # Ghost role stuff
-  - type: GhostRole
-    allowMovement: true
-    name: ghost-role-information-one-star-unit-dungeon-name
-    description: ghost-role-information-one-star-unit-dungeon-description
-    rules: ghost-role-information-dungeon-boss-rules
-    raffle:
-      settings: default
-    mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
-  - type: GhostTakeoverAvailable
+  # - type: GhostRole # CS - disable ghost role
+    # allowMovement: true
+    # name: ghost-role-information-one-star-unit-dungeon-name
+    # description: ghost-role-information-one-star-unit-dungeon-description
+    # rules: ghost-role-information-dungeon-boss-rules
+    # raffle:
+      # settings: default
+    # mindRoles:
+    # - MindRoleGhostRoleTeamAntagonist
+  # - type: GhostTakeoverAvailable
   # Radar
   - type: UserInterface
     interfaces:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

This effectively disables (hopefully all of) the hostile mobs on expeditions and whatever vroids are. It's possible some slipped through the cracks but I'm sure we can figure it out.

Did some basic testing and it seems to work?

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

As they are these kinda of ghost roles just don't seem to be a good fit for the server. They could easily be brought back in the future (maybe with a rework).

## Technical details
<!-- Summary of code changes for easier review. -->

I removed the ghostrole components from a bunch of frontier mobs.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

Generate expeditions and such and see if any ghost roles pop up I guess.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Disabled some hostile ghost roles