### PR TITLE
Fix Janitor jumpsuit loadout

### DIFF
--- a/Resources/Prototypes/_NF/Loadouts/janitor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/janitor_loadout_groups.yml
@@ -7,8 +7,6 @@
   - JanitorNFPlunger
   - JanitorNFClothingHeadHatCone
   - JanitorNFGoldenPlunger
-  subgroups:
-  - CoyoteJumpsuit
 
 - type: loadoutGroup
   id: JanitorNFJumpsuit
@@ -19,6 +17,8 @@
   fallbacks:
   - JanitorNFClothingUniformJumpsuitJanitor
   - JanitorNFClothingUniformJumpskirtJanitor
+  subgroups: # CS
+  - CoyoteJumpsuit
 
 - type: loadoutGroup
   id: JanitorNFGloves


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Moved coyote jumpsuit from the janitor head loadout group to jumpsuit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Janitors no longer attempt to wear jumpsuits on their head.