### PR TITLE
[upstream] re-add part recipes back to the autolathe

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -11,6 +11,8 @@
   - Igniter
   - ModularReceiver
   - MicroManipulatorStockPart
+  - MatterBinStockPart # Frontier
+  - CapacitorStockPart # Frontier
   - ConveyorBeltAssembly
 
 - type: latheRecipePack


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Cherry pick of https://github.com/new-frontiers-14/frontier-station-14/pull/3774

Re-adds the capacitor and matter bin to the autolathe.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Forzii and Alkheemist
- tweak: Re-added capacitor and matter bin to autolathe