### PR TITLE
Space Drake

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/baby_dragon.yml
@@ -3,7 +3,7 @@
   - SimpleSpaceMobBase
   - FlyingMobBase
   id: MobDragonPet
-  name: space drake
+  name: space drake #coyote, renamed from baby dragon and changed desc to match
   description: The smaller cousin to the much larger space dragon.
   components:
   - type: Body
@@ -145,7 +145,7 @@
 - type: entity
   categories: [ HideSpawnMenu ]
   id: BabyDragonsSparkGun
-  name: space drake spark
+  name: space drake spark #coyote renamed from baby dragon spark
   description: A tiny burning ember from a space drake.
   components:
   - type: RechargeBasicEntityAmmo
@@ -163,7 +163,7 @@
   categories: [ HideSpawnMenu ]
   id: ActionDragonsBreathBaby
   parent: BaseAction
-  name: "[color=orange]Drake's Breath[/color]"
+  name: "[color=orange]Drake's Breath[/color]" #coyote renamed from baby dragon's breath
   description: Spew out tiny flames at anyone foolish enough to attack you!
   components:
   - type: Action


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reflavours the baby space dragon mobs into full space drakes, a smaller cousin of the typical space dragon.
All ability names and descriptions should match this change.

These mobs can be possessed as a ghostrole, which breaches server rules, as all playable characters must be adults both mentally and physically. 


**Changelog**
:cl:
tweak: Changes baby dragon to a fully fledged space drake