### PR TITLE
Stop curator librarian PDA pile

### DIFF
--- a/Resources/Prototypes/_CS/Jobs/Curator.yml
+++ b/Resources/Prototypes/_CS/Jobs/Curator.yml
@@ -48,19 +48,16 @@
 - type: startingGear
   id: CuratorGear
   equipment:
-    shoes: ClothingShoesBootsLaceup
-    id: LibrarianPDA
-    ears: ClothingHeadsetService
     pocket1: d20Dice
     pocket2: HandLabeler # for making named bestsellers
   storage:
     back:
     - BookRandom
-    - EncryptionKeyService
-    - EncryptionKeyScience
+    - EncryptionKeyService # TODO: make unique encryption key loadout group and remove this
+    - EncryptionKeyScience # TODO: make unique encryption key loadout group and remove this
     - ShipVoucherCoyoteCurator
 
-# Food Service Ship Voucher
+# Curator Ship Voucher
 - type: entity
   parent: BaseShipVoucher
   id: ShipVoucherCoyoteCurator
@@ -83,7 +80,7 @@
     - Investigator
     - Pulsar
 
-# Food Service Role Loadout
+# Curator Role Loadout
 - type: roleLoadout
   id: JobCurator
   groups:
@@ -98,10 +95,10 @@
   - ContractorFace
   - ContractorGlasses
   - ContractorBelt
-  - ContractorEars
+  - ContractorEars # TODO: should maybe make a unique loadout group to give librarian and science headets for free
   - ContractorEncryptionKey
   - ContractorBoxSurvival
-  - ContractorPDA
+  - ContractorPDA # TODO: make a unique loadout group that gives them librarian (and maybe science?) PDA for free
   - ContractorWallet
   - ContractorCartridge
   - ContractorImplanter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Curators currently get some extra equipment by default, so all of that stuff just dropped to the ground when they spawn. This includes librarian PDAs, which meant a pile of extra PDAs and IDs. I primarily just removed those items from their default loadout, though I also fixed some comments and added some own.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Basically a bugfix.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed curators spawning with extra stuff