### PR TITLE
Harder limiters on asteroid spawning / despawning

### DIFF
--- a/Content.Server/Worldgen/Components/Debris/DebrisFeaturePlacerControllerComponent.cs
+++ b/Content.Server/Worldgen/Components/Debris/DebrisFeaturePlacerControllerComponent.cs
@@ -43,6 +43,11 @@ public sealed partial class DebrisFeaturePlacerControllerComponent : Component
     public Queue<PendingDebrisSpawn> PendingSpawns = new();
 
     /// <summary>
+    ///     Queue of debrises that are scheduled to be despawned.
+    /// </summary>
+    public Queue<EntityUid> PendingDeSpawns = new();
+
+    /// <summary>
     ///     Maximum number of debris entities to spawn per tick (performance tuning).
     /// </summary>
     [DataField("maxSpawnsPerTick")] public int MaxSpawnsPerTick = 5;

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -84,10 +84,22 @@ public sealed partial class CCVars
         CVarDef.Create("entgc.maximum_time_ms", 10, CVar.SERVERONLY); // Frontier: 5<10
 
     /// <summary>
+    ///   Delay in seconds between debris updates (performance tuning).
+    /// </summary>
+    public static readonly CVarDef<int> DebrisDelayBetweenUpdates =
+        CVarDef.Create("debris.seconds_between_updates", 1, CVar.SERVERONLY);
+
+    /// <summary>
     ///     Maximum number of debris entities to spawn per tick (performance tuning).
     /// </summary>
     public static readonly CVarDef<int> DebrisMaxSpawnsPerTick =
         CVarDef.Create("debris.max_spawns_per_tick", 5, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Maximum number of debris entities to DEspawn per tick (performance tuning).
+    /// </summary>
+    public static readonly CVarDef<int> DebrisMaxDeSpawnsPerTick =
+        CVarDef.Create("debris.max_despawns_per_tick", 1, CVar.SERVERONLY);
 
     /// <summary>
     ///     Maximum number of debris grids to build per tick (performance tuning).


### PR DESCRIPTION
The asteroid placer system has a hard limit of asteroids it can spawn and despawn in a given cycle

There is a timer cooldown between (de)spawn cycles

When a chunk is unloaded, the asteroids are entered into a despawn queue

Added some more cvars that only I can use as the sudo queen:
- debris.seconds_between_updates
- debris.max_despawns_per_tick

Tested it out, things spawned as expected, and also despawned as expected too. the cvars worked, and it respected the timer. yay