### PR TITLE
[upstream] Extra Cargo Options Fix

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -40,15 +40,6 @@
   category: cargoproduct-category-name-cargo
   group: market
 
-- type: cargoProduct
-  id: CargoCrusherDagger
-  icon:
-    sprite: Objects/Weapons/Melee/crusher_dagger.rsi
-    state: icon
-  product: CrateCrusherDagger
-  cost: 2500
-  category: cargoproduct-category-name-cargo
-  group: market
 # frontier: Unused
 # - type: cargoProduct
 #   id: CargoCrusherDagger

--- a/Resources/Prototypes/Catalog/Cargo/salvage_rewards.yml
+++ b/Resources/Prototypes/Catalog/Cargo/salvage_rewards.yml
@@ -1,83 +1,85 @@
-# Rank 2
-- type: cargoProduct
-  id: CargoDoubleEmergencyTank
-  icon:
-    sprite: Objects/Tanks/emergency_double.rsi
-    state: icon
-  product: CrateDoubleEmergencyTank
-  cost: 2400
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+#Frontier: Removes the equipment from the cargo order pool
+ # Rank 2
+# - type: cargoProduct
+#   id: CargoDoubleEmergencyTank
+#   icon:
+#     sprite: Objects/Tanks/emergency_double.rsi
+#     state: icon
+#   product: CrateDoubleEmergencyTank
+#   cost: 2400
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-- type: cargoProduct
-  id: CargoSeismicCharge
-  icon:
-    sprite: Objects/Weapons/Bombs/seismic.rsi
-    state: icon
-  product: CrateSeismicCharge
-  cost: 1800
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+# - type: cargoProduct
+#   id: CargoSeismicCharge
+#   icon:
+#     sprite: Objects/Weapons/Bombs/seismic.rsi
+#     state: icon
+#   product: CrateSeismicCharge
+#   cost: 1800
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-- type: cargoProduct
-  id: CargoCrusher
-  icon:
-    sprite: Objects/Weapons/Melee/crusher.rsi
-    state: icon
-  product: CrateCrusher
-  cost: 5000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+# - type: cargoProduct
+#   id: CargoCrusher
+#   icon:
+#     sprite: Objects/Weapons/Melee/crusher.rsi
+#     state: icon
+#   product: CrateCrusher
+#   cost: 5000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-- type: cargoProduct
-  id: CargoSalvageHardsuit
-  icon:
-    sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
-    state: icon
-  product: CrateSalvageHardsuit
-  cost: 7500
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward2
+# - type: cargoProduct
+#   id: CargoSalvageHardsuit
+#   icon:
+#     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
+#     state: icon
+#   product: CrateSalvageHardsuit
+#   cost: 7500
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward2
 
-# Rank 3
-- type: cargoProduct
-  id: CargoFulton
-  icon:
-    sprite: /Textures/Objects/Tools/fulton.rsi
-    state: extraction_pack
-  product: CrateFulton
-  cost: 3000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward3
+# # Rank 3
+# - type: cargoProduct
+#   id: CargoFulton
+#   icon:
+#     sprite: /Textures/Objects/Tools/fulton.rsi
+#     state: extraction_pack
+#   product: CrateFulton
+#   cost: 3000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward3
 
-- type: cargoProduct
-  id: CargoVoidJetpack
-  icon:
-    sprite: Objects/Tanks/Jetpacks/void.rsi
-    state: icon
-  product: CrateVoidJetpack
-  cost: 4000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward3
+# - type: cargoProduct
+#   id: CargoVoidJetpack
+#   icon:
+#     sprite: Objects/Tanks/Jetpacks/void.rsi
+#     state: icon
+#   product: CrateVoidJetpack
+#   cost: 4000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward3
 
-- type: cargoProduct
-  id: CargoCrusherGlaive
-  icon:
-    sprite: Objects/Weapons/Melee/crusher_glaive.rsi
-    state: icon
-  product: CrateCrusherGlaive
-  cost: 8000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobReward3
+# - type: cargoProduct
+#   id: CargoCrusherGlaive
+#   icon:
+#     sprite: Objects/Weapons/Melee/crusher_glaive.rsi
+#     state: icon
+#   product: CrateCrusherGlaive
+#   cost: 8000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobReward3
 
-# Max Rank
+# # Max Rank
 
-- type: cargoProduct
-  id: CargoSupremeSalvagerCloak
-  icon:
-    sprite: Clothing/Neck/Cloaks/miner.rsi
-    state: icon
-  product: CrateSupremeSalvagerCloak
-  cost: 25000
-  category: cargoproduct-category-name-cargo
-  group: SalvageJobRewardMAX
+# - type: cargoProduct
+#   id: CargoSupremeSalvagerCloak
+#   icon:
+#     sprite: Clothing/Neck/Cloaks/miner.rsi
+#     state: icon
+#   product: CrateSupremeSalvagerCloak
+#   cost: 25000
+#   category: cargoproduct-category-name-cargo
+#   group: SalvageJobRewardMAX
+#End Frontier


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

There were some items, including the void jetpack, that were appearing as available in the cargo request computer when they were not supposed to be. You couldn't even buy them, adding even more confusion. This grabs the upstream PR that fixes it, though I must admit I'm not a fan of HOW they fixed it.

Out-of-order Cherry-pick of https://github.com/new-frontiers-14/frontier-station-14/pull/3784

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL, see Frontier changelog