### PR TITLE
nerfs prototype pulse rifle

### DIFF
--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -27,10 +27,10 @@
       path: /Audio/Weapons/Guns/Gunshots/laser3.ogg
   - type: HitscanBatteryAmmoProvider
     proto: PulseWeak # Flooftier Weak Pulse Rifle
-    fireCost: 60
+    fireCost: 80
   - type: Battery
-    maxCharge: 1560
-    startingCharge: 1560
+    maxCharge: 2400
+    startingCharge: 2400
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 30
+    autoRechargeRate: 4


### PR DESCRIPTION
see title

the prototype pulse rifle *did* (32 * 2.4) 76.8 DPS. 
the laser carbine (weapon it's based off of) does (37 * 1.9) 70.3 DPS


this is typically fine but it's a rapid fire hitscan laser weapon in a damage type no one wears armor in meaning it had a disproportionally high lethality rate compared to the regular laser carbine (which took skill to use as it's a precision weapon).

reduced to (32 * 2.2) 70.4 DPS. 
additionally, nerfed the charge rate so it now no longer has nigh infinite ammo. I seriously have to *test* y'alls PRs internet speed be damned.
more adjustments in the future if needed.
