### PR TITLE
Make smuggler always spawn with smuggler PDA

### DIFF
--- a/Resources/Prototypes/_CS/Loadouts/smuggler_loadout_groups.yml
+++ b/Resources/Prototypes/_CS/Loadouts/smuggler_loadout_groups.yml
@@ -1,12 +1,13 @@
 - type: loadoutGroup
   id: SmugglerPDA
   name: loadout-group-contractor-pda
-  hidden: false # No point in showing this, it gets auto-selected. # Coyote: But what if...
+  hidden: true # No point in showing this, it gets auto-selected.
   loadouts:
   - SmugglerSmugglerPDA
-  subgroups:
-  - MercenaryPDA
-  - PilotPDA
-  - ContractorPDA
-  fallbacks:
-  - NFPirateNFPiratePDA
+  # - NFPirateNFPiratePDA
+  # subgroups:
+  # - MercenaryPDA
+  # - PilotPDA
+  # - ContractorPDA
+  # fallbacks:
+  # - SmugglerSmugglerPDA


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The options for the smuggler PDA and the fallback being the pirate ID was confusing people, causing multiple ahelps and at least one bug report. I left the options commented out, with some tweaks, in case we ever want to restore it in the future.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Reduce confusion and admin load. Default is a chameleon PDA/ID so you can make it into whatever you want anyway.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Made smugglers always spawn with chameleon PDA and ID