### PR TITLE
LL1 Jabber (Cargo Shuttle)

### DIFF
--- a/Resources/Maps/_NF/Shuttles/jabber.yml
+++ b/Resources/Maps/_NF/Shuttles/jabber.yml
@@ -845,10 +845,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
       parent: 1
-    - type: Thruster
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 1
 - proto: FaxMachineShip
   entities:
   - uid: 159

--- a/Resources/Prototypes/_NF/Guidebook/shipyard.yml
+++ b/Resources/Prototypes/_NF/Guidebook/shipyard.yml
@@ -38,6 +38,7 @@
   - ShipyardHonker
   - ShipyardInvestigator
   - ShipyardIzakaya
+  - ShipyardJabber
   - ShipyardKestrel
   - ShipyardKilderkin
   - ShipyardLegman
@@ -234,6 +235,11 @@
   id: ShipyardIzakaya
   name: guide-entry-shipyard-izakaya
   text: "/ServerInfo/_NF/Guidebook/Shipyard/Izakaya.xml"
+
+- type: guideEntry
+  id: ShipyardJabber
+  name: guide-entry-shipyard-jabber
+  text: "/ServerInfo/_NF/Guidebook/Shipyard/Jabber.xml"
 
 - type: guideEntry
   id: ShipyardKestrel

--- a/Resources/Prototypes/_NF/Shipyard/jabber.yml
+++ b/Resources/Prototypes/_NF/Shipyard/jabber.yml
@@ -7,7 +7,7 @@
   parent: BaseVessel
   name: LL1 Jabber
   description: A cargo shuttle focusing on comfort, has an advanced dragon thruster to help it get to voidports.
-  price: 29000 # 10481 0.05 11005.05
+  price: 21750 # 17,339, LL1 125% (higher end for LL1, it has a dragon thruster)
   category: Small
   group: Shipyard
   shuttlePath: /Maps/_NF/Shuttles/jabber.yml

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Camper.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Camper.xml
@@ -27,20 +27,12 @@
   ## 1. Power supply
   
   ## 1.1. Battery units
-  <Box>
-  <GuideEntityEmbed Entity="SubstationWallBasic"/>
-  <GuideEntityEmbed Entity="APCBasic"/>
-  </Box>
 
   - Check that the substation unit is anchored to the wall.
   - Check that the APC unit's Main Breaker is toggled on.
   - Check the APC unit's current Load (W).
   
   ## 1.2. P.A.C.M.A.N. generator unit.
-  <Box>
-  <GuideEntityEmbed Entity="PortableGeneratorPacmanShuttle"/>
-  <GuideEntityEmbed Entity="SheetPlasma"/>
-  </Box>
   
   - Check that P.A.C.M.A.N. generator units are anchored to the floor.
   - Check that P.A.C.M.A.N. generator units are fueled. For extended flights make sure that you have enough fuel stockpiled to sustain prolonged power generation.

--- a/Resources/ServerInfo/_NF/Guidebook/Shipyard/Jabber.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Shipyard/Jabber.xml
@@ -1,0 +1,46 @@
+<Document>
+  # CARGO-CLASS PERSONAL SHUTTLE
+  <Box>
+  <GuideEntityEmbed Entity="ChairPilotSeat" Caption="Cockpit"/>
+  <GuideEntityEmbed Entity="Bed" Caption="Bedroom"/>
+  <GuideEntityEmbed Entity="ComputerTelevision" Caption="Lounge"/>
+  <GuideEntityEmbed Entity="CrateStorageRack" Caption="Storage"/>
+  </Box>
+
+  [color=#a4885c]Ship Size:[/color] Small
+	
+  [color=#a4885c]Recommended Crew:[/color] 1-2
+	
+  [color=#a4885c]Power Gen Type:[/color] Plasma
+	
+  [color=#a4885c]Expeditions:[/color] No
+	
+  "A cargo shuttle focusing on comfort and lite atmosphere, has an advanced dragon thruster to help it get to voidports."
+
+  # OWNERS MANUAL
+
+  ## 1. Shuttle Console Ports
+  ## 1.a List of Ports
+  "Find below a list of the shuttle console's port's and their linked functions:"
+  - \[Port 1\]: Engage low power thrusters.
+  - \[Port 2\]: Disengage all thrusters.
+  - \[Port 3\]: Engage high power thrusters (Forward only).
+
+  ## 1.b Initial Setup
+  - Due to manufacturing limitations, please engage your shuttle consoles \[Port 1\] at your earliest convenience to avoid wasted power.
+  
+  ## 2. Optimal Use.
+  ## 2.a. Thruster Settings
+
+  - The Jabber comes equipped with a single Dragon Thruster, which is a high-output thruster capable of reaching greater speeds, however it consumes a lot of power while active.
+  - Take note of the Substations Load (kW).
+  - If planning to use high power mode (\[Port 3\]), it is recommeneded to have your P.A.C.M.A.N generator set to 20kw, otherwise it is recommended to have the generator set to 13kW
+  
+  ## 2.b. P.A.C.M.A.N. generator unit.
+
+  - The Jabber comes with a P.A.C.M.A.N generator to supply power to the shuttle's systems.
+  - This generator uses plasma as fuel, which can be bought at most locations via fuel vendors, it also accepts plasma ore, and plasma sheets.
+  - It is recommeneded to have at least 10 sheets of plasma spare in the wall closet located in the engineering room for emergencies.
+  - In the event of a power crisis, it is recommeneded to use \[Port 2\] on the shuttle console to disable all thrusters and allow the substation to recharge, it is also recommended to unanchor any non-essential electrical equipment to reduce power draw.
+
+</Document>


### PR DESCRIPTION
## About the PR
The LL1 Jabber
priced at 21,750$ at the regular shipyard,
this shuttle comes with a single forward dragon prelinked to the shuttle console to allow toggling between mules/dragon speed.
It is primarily for hauling small amounts of cargo similar to the hotdog but with a better focus on being a shuttle that has more room to breathe, think if the hotdog and camper had a baby.

For movement it has 2/1 mule/dragon forward thrusters, 1 for lateral and 2 reverse, with 1 gyroscopes
Its total power consumption comes in at just under 13kw (20kw when running the dragon) and comes with a single P.A.C.M.A.N.

## Why / Balance
Helps fill out our repertoire of custom shuttles.
Its single dragon is tempting for early powerspikes but given the shuttles lacking all other supplies and tools its not as appealing for someone looking to get a head start.

## Technical details
its a shuttle.

## How to test
Go buy it from the regular shipyard console and test out its ports.

## Media
![ss+(2025-11-19+at+08 02 27)](https://github.com/user-attachments/assets/f1bb89d0-d025-49a9-b59c-b31da46e8c0f)
<img width="206" height="241" alt="ss+(2025-11-19+at+08 02 35)" src="https://github.com/user-attachments/assets/a2553429-b8eb-4ba8-a2c7-4c2a1d2fe965" />


## Breaking changes
*yes the dragon is on by default, sadly due to a bug you cannot have thrusters mapped in their off state, else their power consumption when used is set to 1 watt. see #475 
