### PR TITLE
Quiets various atmos noise-makers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/trinary.yml
@@ -69,8 +69,8 @@
       node: filter
     - type: AmbientSound
       enabled: false
-      volume: -9
-      range: 5
+      volume: -12
+      range: 2.5
       sound:
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: AtmosMonitoringConsoleDevice
@@ -168,8 +168,8 @@
       node: mixer
     - type: AmbientSound
       enabled: false
-      volume: -9
-      range: 5
+      volume: -12
+      range: 2.5
       sound:
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: AtmosMonitoringConsoleDevice
@@ -271,8 +271,8 @@
     - type: PressureControlledValve
     - type: AmbientSound
       enabled: false
-      volume: -9
-      range: 5
+      volume: -12
+      range: 2.5
       sound:
         path: /Audio/Ambience/Objects/gas_hiss.ogg
     - type: Construction

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -67,8 +67,8 @@
     - type: VentCritterSpawnLocation
     - type: AmbientSound
       enabled: true
-      volume: -12
-      range: 5
+      volume: -15
+      range: 2.5
       sound:
         path: /Audio/Ambience/Objects/gas_vent.ogg
     - type: Weldable
@@ -159,8 +159,8 @@
       node: ventscrubber
     - type: AmbientSound
       enabled: true
-      volume: -12
-      range: 5
+      volume: -15
+      range: 2.5
       sound:
         path: /Audio/Ambience/Objects/gas_vent.ogg
     - type: Weldable


### PR DESCRIPTION
## About the PR
an extension of #385
dampens sounds of many atmos devices that are on all ships, such as mixers manual valves and vents.

## Why / Balance
see previous PR

## Technical details
see previous PR
