### PR TITLE
Quick fix for the Peeper showing up as a grid still.

### DIFF
--- a/Resources/Prototypes/_CS/Shipyard/BlackMarket/Escort/peeper.yml
+++ b/Resources/Prototypes/_CS/Shipyard/BlackMarket/Escort/peeper.yml
@@ -25,7 +25,7 @@
   mapPath: /Maps/_CS/Shuttles/BlackMarket/Escort/peeper.yml
   minPlayers: 0
   stations:
-    Speakeasy:
+    Peeper:
       stationProto: StandardFrontierAntagVessel
       components:
         - type: StationNameSetup


### PR DESCRIPTION
## About the PR
fixes the peeper

## Why / Balance
grid bad

## Technical details
it was id'd as a speakeasy

## How to test
buy it