### PR TITLE
No more powergamey gas factories

### DIFF
--- a/Resources/Prototypes/Hydroponics/randomMutations.yml
+++ b/Resources/Prototypes/Hydroponics/randomMutations.yml
@@ -172,10 +172,11 @@
       baseOdds: 0.072
       persists: false
       effect: !type:PlantMutateChemicals
-    - name: ChangeExudeGasses
-      baseOdds: 0.0145
-      persists: false
-      effect: !type:PlantMutateExudeGasses
+    # Coyote change - Encourages economy breaking factories
+    #- name: ChangeExudeGasses
+    #  baseOdds: 0.0145
+    #  persists: false
+    #  effect: !type:PlantMutateExudeGasses
     - name: ChangeConsumeGasses
       baseOdds: 0.0036
       persists: false


### PR DESCRIPTION
I kinda ran into this rule unknowingly before it became public proper. Though after talking with jaegurt, to properly prevent this from happening again and causing mega lag it has been disabled to not encourage that behavior again. People can still gas mine and that should be the intended way to get gasses. 