### PR TITLE
[wizden] Fix RGB Staff

### DIFF
--- a/Resources/Prototypes/Magic/staves.yml
+++ b/Resources/Prototypes/Magic/staves.yml
@@ -70,6 +70,7 @@
   parent: BaseAction
   id: ActionRgbLight
   components:
+  - type: TargetAction
   - type: EntityTargetAction
     whitelist: { components: [ PointLight ] }
     event: !type:ChangeComponentsSpellEvent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The RGB staff doesn't work due to Wizden changes. Wizden fixed this issue though I don't believe the fix has made it to upstream yet (and we're even further behind).

This cherry-picks the fix - https://github.com/space-wizards/space-station-14/pull/40258

Quick testing shows that this should be good to go.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Steffo99
- fix: Fixed the RGB staff not working.