### PR TITLE
"Character OOC Freetext Wipes on Reconnect" Fix

### DIFF
--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -282,7 +282,7 @@ namespace Content.Server.Preferences.Managers
             }
         }
 
-        public void FinishLoad(ICommonSession session)
+        public async void FinishLoad(ICommonSession session)
         {
             // This is a separate step from the actual database load.
             // Sanitizing preferences requires play time info due to loadouts.
@@ -300,6 +300,14 @@ namespace Content.Server.Preferences.Managers
                 MaxCharacterSlots = MaxCharacterSlots
             };
             _netManager.ServerSendMessage(msg, session.Channel);
+
+            // Reload character consent now that preferences are fully loaded
+            // This ensures character-specific consent freetext is loaded correctly
+            if (ShouldStorePrefs(session.Channel.AuthType))
+            {
+                var characterSlot = prefsData.Prefs.SelectedCharacterIndex;
+                await _consentManager.ReloadCharacterConsent(session.UserId, characterSlot);
+            }
 
             // Frontier: notify other entities that your player data is loaded.
             if (session.AttachedEntity != null)


### PR DESCRIPTION
## About the PR
- Fixes loses Character OOC Freetext on reconnect 

Addresses issue #594. Shoutout to Sunless for this discovery/report.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
The issue is that preferences and consent load concurrently through the `UserDbDataManager`, so there's a race condition. The consent might load before preferences are available, causing it to only load the account-level consent (without the character-specific freetext).

The fix is to add a call to reload character consent in the `FinishLoad` method of `ServerPreferencesManager` after preferences are finalized. This will ensure that the character-specific consent is loaded correctly.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
