### PR TITLE
Add Size Reverter system and components for size normalization

### DIFF
--- a/Content.Server/_CS/Body/Systems/SizeReverterSystem.cs
+++ b/Content.Server/_CS/Body/Systems/SizeReverterSystem.cs
@@ -1,0 +1,145 @@
+using Content.Server.Body.Systems;
+using Content.Shared.Body.Components;
+using Content.Shared.Construction.Components;
+using Content.Shared.HeightAdjust;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Popups;
+using Robust.Server.GameObjects;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CS.Body.Systems;
+
+/// <summary>
+/// System that handles size reverters - items that revert players to acceptable sizes
+/// when they walk past within a certain range.
+/// </summary>
+public sealed class SizeReverterSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SizeManipulationSystem _sizeManipulation = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SizeReverterComponent, AnchorStateChangedEvent>(OnAnchorChanged);
+        SubscribeLocalEvent<SizeReverterComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+    }
+
+    private void OnAnchorChanged(EntityUid uid, SizeReverterComponent component, ref AnchorStateChangedEvent args)
+    {
+        component.IsActive = args.Anchored;
+        Dirty(uid, component);
+
+        // Update appearance
+        _appearance.SetData(uid, SizeReverterVisuals.Active, args.Anchored);
+    }
+
+    private void OnUnanchorAttempt(EntityUid uid, SizeReverterComponent component, UnanchorAttemptEvent args)
+    {
+        // Add a 30 second delay to unwrenching
+        args.Delay += (float)component.UnanchorDelay.TotalSeconds;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<SizeReverterComponent, TransformComponent>();
+        var curTime = _timing.CurTime;
+
+        while (query.MoveNext(out var uid, out var reverter, out var xform))
+        {
+            // Only process if active (anchored) and update interval has passed
+            if (!reverter.IsActive || curTime < reverter.NextUpdate)
+                continue;
+
+            reverter.NextUpdate = curTime + TimeSpan.FromSeconds(reverter.UpdateInterval);
+
+            // Get all entities within range
+            var reverterPos = _transform.GetWorldPosition(xform);
+            var nearbyEntities = new List<Entity<MobStateComponent, SizeAffectedComponent, TransformComponent>>();
+
+            var mobQuery = EntityQueryEnumerator<MobStateComponent, SizeAffectedComponent, TransformComponent>();
+            while (mobQuery.MoveNext(out var mobUid, out var mobState, out var sizeAffected, out var mobXform))
+            {
+                // Skip if not in same map
+                if (mobXform.MapID != xform.MapID)
+                    continue;
+
+                var mobPos = _transform.GetWorldPosition(mobXform);
+                var distance = (mobPos - reverterPos).Length();
+
+                // Check if within range
+                if (distance <= reverter.Range)
+                {
+                    nearbyEntities.Add((mobUid, mobState, sizeAffected, mobXform));
+                }
+            }
+
+            // Process each nearby entity
+            foreach (var entity in nearbyEntities)
+            {
+                var currentScale = entity.Comp2.ScaleMultiplier;
+
+                // Check if size is out of acceptable range
+                if (currentScale > reverter.MaxAcceptableSize)
+                {
+                    // Too large, revert down
+                    entity.Comp2.ScaleMultiplier = reverter.RevertToLarge;
+                    Dirty(entity, entity.Comp2);
+
+                    // Request size recalculation
+                    var recalcEvent = new RequestSizeRecalcEvent();
+                    RaiseLocalEvent(entity, ref recalcEvent);
+
+                    // Play subtle effect
+                    PlaySizeReversionEffect(entity);
+
+                    _popup.PopupEntity(
+                        Loc.GetString("size-reverter-normalized-large"),
+                        entity,
+                        PopupType.Medium);
+                }
+                else if (currentScale < reverter.MinAcceptableSize)
+                {
+                    // Too small, revert up
+                    entity.Comp2.ScaleMultiplier = reverter.RevertToSmall;
+                    Dirty(entity, entity.Comp2);
+
+                    // Request size recalculation
+                    var recalcEvent = new RequestSizeRecalcEvent();
+                    RaiseLocalEvent(entity, ref recalcEvent);
+
+                    // Play subtle effect
+                    PlaySizeReversionEffect(entity);
+
+                    _popup.PopupEntity(
+                        Loc.GetString("size-reverter-normalized-small"),
+                        entity,
+                        PopupType.Medium);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Plays a subtle visual and audio effect when a player's size is reverted
+    /// </summary>
+    private void PlaySizeReversionEffect(EntityUid target)
+    {
+        // Spawn a subtle blue sparkle effect at the target's location
+        var effect = Spawn("EffectFlashBluespaceQuiet", Transform(target).Coordinates);
+
+        // Play a quiet shimmer/whoosh sound
+        _audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg"), target,
+            AudioParams.Default.WithVolume(-8f).WithVariation(0.05f));
+    }
+}

--- a/Content.Shared/_CS/Body/Components/SizeReverterComponent.cs
+++ b/Content.Shared/_CS/Body/Components/SizeReverterComponent.cs
@@ -1,0 +1,67 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Body.Components;
+
+/// <summary>
+/// Component for items that revert players back to acceptable size thresholds
+/// when they walk past within a certain range.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class SizeReverterComponent : Component
+{
+    /// <summary>
+    /// The range in tiles that the size reverter affects
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Range = 3f;
+
+    /// <summary>
+    /// Maximum acceptable size multiplier. If player is larger than this, they will be reverted.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float MaxAcceptableSize = 2.0f;
+
+    /// <summary>
+    /// Minimum acceptable size multiplier. If player is smaller than this, they will be reverted.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float MinAcceptableSize = 0.5f;
+
+    /// <summary>
+    /// Target size to revert to when player is too large
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float RevertToLarge = 1.8f;
+
+    /// <summary>
+    /// Target size to revert to when player is too small
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float RevertToSmall = 0.6f;
+
+    /// <summary>
+    /// How often to check for nearby players (in seconds)
+    /// </summary>
+    [DataField]
+    public float UpdateInterval = 0.5f;
+
+    /// <summary>
+    /// Delay in seconds before the device can be unwrenched/unanchored
+    /// </summary>
+    [DataField]
+    public TimeSpan UnanchorDelay = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Next time to check for players
+    /// </summary>
+    [DataField]
+    public TimeSpan NextUpdate = TimeSpan.Zero;
+
+    /// <summary>
+    /// Whether the size reverter is currently active (requires anchoring)
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IsActive = false;
+}

--- a/Content.Shared/_CS/Body/Components/SizeReverterVisuals.cs
+++ b/Content.Shared/_CS/Body/Components/SizeReverterVisuals.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Body.Components;
+
+[Serializable, NetSerializable]
+public enum SizeReverterVisuals : byte
+{
+    Active
+}
+
+[Serializable, NetSerializable]
+public enum SizeReverterLayers : byte
+{
+    Base
+}

--- a/Resources/Locale/en-US/_CS/size-reverter.ftl
+++ b/Resources/Locale/en-US/_CS/size-reverter.ftl
@@ -1,0 +1,3 @@
+## Size Reverter
+size-reverter-normalized-large = You feel your size being normalized back to acceptable levels.
+size-reverter-normalized-small = You feel your size being normalized back to acceptable levels.

--- a/Resources/Prototypes/_CS/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_CS/Catalog/Cargo/cargo_engineering.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: SizeNormalizer
+  icon:
+    sprite: Structures/Specific/Atmospherics/sensor.rsi
+    state: gsensor0
+  product: SizeReverter
+  cost: 10000
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/_CS/Entities/Objects/Devices/size_reverter.yml
+++ b/Resources/Prototypes/_CS/Entities/Objects/Devices/size_reverter.yml
@@ -1,0 +1,57 @@
+- type: entity
+  id: SizeReverter
+  name: size normalizer
+  description: A device that automatically reverts nearby personnel to acceptable size thresholds. Must be anchored to function.
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: Transform
+    anchored: false
+  - type: Sprite
+    sprite: Structures/Specific/Atmospherics/sensor.rsi
+    drawdepth: FloorObjects
+    layers:
+    - state: gsensor0
+      map: [ "enum.SizeReverterLayers.Base" ]
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 60
+        mask:
+        - ItemMask
+  - type: Anchorable
+  - type: Pullable
+  - type: SizeReverter
+    range: 3.0
+    maxAcceptableSize: 2.0
+    minAcceptableSize: 0.5
+    revertToLarge: 1.90  # 1.0 + (0.15 * 6) - aligns with size manipulator increments
+    revertToSmall: 0.70  # 1.0 - (0.15 * 2) - aligns with size manipulator increments
+    updateInterval: 0.5
+  - type: Item
+    size: Normal
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.SizeReverterVisuals.Active:
+        enum.SizeReverterLayers.Base:
+          True: { state: gsensor1 }
+          False: { state: gsensor0 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Adds a new deployable device that automatically reverts nearby players to acceptable size thresholds.
- Proximity-based size correction: Detects players within 3 tiles and normalizes their size if outside acceptable bounds
- Configurable thresholds:
  - Players >2.0x scale → reverted to 1.90x
  - Players <0.5x scale → reverted to 0.70x
  - Revert values align with size manipulator's 0.15x increments for precise control
- Must be anchored: Device only activates when wrenched to the ground
- Visual & audio feedback: Subtle bluespace flash and teleport sound when size is corrected

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
- Scans every 0.5 seconds to avoid any intensive checks.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<img width="1137" height="515" alt="image" src="https://github.com/user-attachments/assets/22302976-c2cb-4a23-8bb2-92c602ee9d14" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [x] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
