### PR TITLE
Refactor AnomalyComponent properties to use clamped values

### DIFF
--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -20,6 +20,10 @@ namespace Content.Shared.Anomaly.Components;
 [Access(typeof(SharedAnomalySystem), typeof(SharedInnerBodyAnomalySystem))]
 public sealed partial class AnomalyComponent : Component
 {
+    private float _stability = 0f;
+    private float _severity = 0f;
+    private float _health = 1f;
+
     /// <summary>
     /// How likely an anomaly is to grow more dangerous. Moves both up and down.
     /// Ranges from 0 to 1.
@@ -31,7 +35,11 @@ public sealed partial class AnomalyComponent : Component
     /// value that only matters in relation to the <see cref="GrowthThreshold"/> and <see cref="DecayThreshold"/>
     /// </remarks>
     [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float Stability = 0f;
+    public float Stability
+    {
+        get => _stability;
+        set => _stability = Math.Clamp(value, 0f, 1f);
+    }
 
     /// <summary>
     /// How severe the effects of an anomaly are. Moves only upwards.
@@ -43,7 +51,11 @@ public sealed partial class AnomalyComponent : Component
     /// Wacky-Stability scale lives on in my heart. - emo
     /// </remarks>
     [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float Severity = 0f;
+    public float Severity
+    {
+        get => _severity;
+        set => _severity = Math.Clamp(value, 0f, 1f);
+    }
 
     #region Health
     /// <summary>
@@ -53,7 +65,11 @@ public sealed partial class AnomalyComponent : Component
     /// reaching a supercritical point.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public float Health = 1f;
+    public float Health
+    {
+        get => _health;
+        set => _health = Math.Clamp(value, 0f, 1f);
+    }
 
     /// <summary>
     /// If the <see cref="Stability"/> of the anomaly exceeds this value, it


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The `Severity` field on line 45 allows admins to directly edit it via View Variables. When they set it to 9999, it bypasses the clamping in `ChangeAnomalySeverity` and can cause crashes.

The solution here is to add a property with clamping. **Please test this before merging.**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<img width="457" height="99" alt="image" src="https://github.com/user-attachments/assets/292f1197-9e85-4f83-99b4-2d8817f00d3e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [ ] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
