### PR TITLE
[Staff Discussion required] Removes powered door prying from jaws of life

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -25,7 +25,7 @@
     useSound: /Audio/Items/jaws_pry.ogg
   - type: Prying
     speedModifier: 1.5
-    pryPowered: true
+    pryPowered: false # Coyote: removed jawsing through powered, access locked doors
     useSound: /Audio/Items/jaws_pry.ogg
   - type: MultipleTool
     statusShowBehavior: true
@@ -68,6 +68,7 @@
     size: Normal
   - type: Prying
     speedModifier: 3.0
+    pryPowered: true #Coyote: jaws of death won't work without this if jaws of life don't have this
   - type: MultipleTool
     entries:
       - behavior: Prying


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Powered doors can no longer be pried by the jaws of life. Jaws of death retain this feature.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The tl;dr is that the "logical and sensible" uses of this were outweighed pretty heavily by its overwhelmingly negative uses.

The longer story of it is that jaws of life are incredibly easy to get and allow you to access any access locked area anywhere, with little to no recourse, and zero IC traceability. There are no fibers, no prints, and no indication that you did it. It was basically a tider tool and you can get it roundstart from an engifab for a paltry cost of common resources. It made detective gameplay miserable and made keeping access locked areas actually access locked an impossible task without turret spam (and turrets can be fooled too). It was also, in a way, ban bait because it made it trivial to try and break into places like the NFSDO or den backrooms without following raid rules.

The reason why this is up for staff discussion is that this 100% forces players to doorhack or EMP then pry unless they get jaws of death or a breaching hammer. It's a change of pace for gameplay and one I think is for the better, but even with an admin recommendation I still think this is large enough of a change to warrant discussion.

A note:
- NFSD pretty heavily uses jaws of life as a way to non-destructively breach ships after disabling with an emp. breaching hammers require a duffel, suit slot, or BS bag in order to carry them and are quite large. Consider adding an NFSD specific jaws of life that has `pryPowered` still, give them a tool to do a 1 tile temporary emp for door depowering, or alter breaching hammers to be more worth it so people don't just start using breaching charges and venting ships instead.
## Technical details
<!-- Summary of code changes for easier review. -->
removed `pryPowered` from jaws of life
added `pryPowered` to jaws of death because it was a jaws of life child
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
find powered door
grab both jaws types
fail to open door with jaws of life
succeed at opening door with jaws of death
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: tank8673
- remove: prying powered doors with the jaws of life. jaws of death retains the ability, however.