### PR TITLE
reduces average vgroid count slightly and removes most of the floor clutter

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -30,7 +30,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minCount: 1 # Coyote add: make it vary from one
-        maxCount: 3 # Coyote add: to three instances
+        maxCount: 2 # Coyote add: to two instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: &dungeonComponents
@@ -61,7 +61,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minCount: 1 # Coyote add: make it vary from one
-        maxCount: 3 # Coyote add: to three instances
+        maxCount: 2 # Coyote add: to two instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -78,7 +78,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minCount: 1 # Coyote add: make it vary from one
-        maxCount: 3 # Coyote add: to three instances
+        maxCount: 2 # Coyote add: to two instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -95,7 +95,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minCount: 1 # Coyote add: make it vary from one
-        maxCount: 3 # Coyote add: to three instances
+        maxCount: 2 # Coyote add: to two instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -112,7 +112,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minCount: 1 # Coyote add: make it vary from one
-        maxCount: 3 # Coyote add: to three instances
+        maxCount: 2 # Coyote add: to two instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -129,7 +129,7 @@
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
         minCount: 1 # Coyote add: make it vary from one
-        maxCount: 3 # Coyote add: to three instances
+        maxCount: 2 # Coyote add: to two instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -204,30 +204,30 @@
   layers:
   - !type:ExteriorDunGen
     proto: NFLavaMercenary
-  - !type:EntityTableDunGen
-    minCount: 25
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerValuable
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageTreasureSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerCommon
-    perDungeon: true
+  # - !type:EntityTableDunGen # Coyote remove start: Remove MOST of the floor clutter to try and save on lag
+    # minCount: 25
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerCommon
+    # erDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 30
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerValuable
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageTreasureSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageEquipmentSpawnerCommon
+    # perDungeon: true # Coyote remove end: Remove MOST of the floor clutter to try and save on lag
   - !type:EntityTableDunGen
     minCount: 15
     maxCount: 20

--- a/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
@@ -204,30 +204,30 @@
   layers:
   - !type:ExteriorDunGen
     proto: NFSalvageOutpost
-  - !type:EntityTableDunGen
-    minCount: 25
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerValuable
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageTreasureSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerCommon
-    perDungeon: true
+  # - !type:EntityTableDunGen # Coyote remove start: Remove MOST of the floor clutter to try and save on lag
+    # minCount: 25
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 30
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerValuable
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageTreasureSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageEquipmentSpawnerCommon
+    # perDungeon: true # Coyote remove end: Remove MOST of the floor clutter to try and save on lag
   - !type:EntityTableDunGen
     minCount: 15
     maxCount: 20

--- a/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
@@ -204,30 +204,30 @@
   layers:
   - !type:ExteriorDunGen
     proto: NFVirologyLab
-  - !type:EntityTableDunGen
-    minCount: 25
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerValuable
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageTreasureSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerCommon
-    perDungeon: true
+  # - !type:EntityTableDunGen # Coyote remove start: Remove MOST of the floor clutter to try and save on lag
+    # minCount: 25
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 30
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerValuable
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageTreasureSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageEquipmentSpawnerCommon
+    # perDungeon: true # Coyote remove end: Remove MOST of the floor clutter to try and save on lag
   - !type:EntityTableDunGen
     minCount: 15
     maxCount: 20

--- a/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
@@ -225,30 +225,30 @@
   layers:
   - !type:ExteriorDunGen
     proto: NFSnowyLabs
-  - !type:EntityTableDunGen
-    minCount: 25
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerValuable
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageTreasureSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerCommon
-    perDungeon: true
+  # - !type:EntityTableDunGen # Coyote remove start: Remove MOST of the floor clutter to try and save on lag
+    # minCount: 25
+    # maxCount: 40
+    # able: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 30
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # ableId: SalvageScrapSpawnerValuable
+    # erDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageTreasureSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageEquipmentSpawnerCommon
+    # perDungeon: true # Coyote remove end: Remove MOST of the floor clutter to try and save on lag
   - !type:EntityTableDunGen
     minCount: 15
     maxCount: 20

--- a/Resources/Prototypes/_NF/Procedural/zombie_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/zombie_vgroid.yml
@@ -154,30 +154,30 @@
   layers:
   - !type:ExteriorDunGen
     proto: NFVirologyLab
-  - !type:EntityTableDunGen
-    minCount: 25
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 30
-    maxCount: 40
-    table: !type:NestedSelector
-      tableId: SalvageScrapSpawnerValuable
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageTreasureSpawnerCommon
-    perDungeon: true
-  - !type:EntityTableDunGen
-    minCount: 15
-    maxCount: 25
-    table: !type:NestedSelector
-      tableId: SalvageEquipmentSpawnerCommon
-    perDungeon: true
+  # - !type:EntityTableDunGen # Coyote remove start: Remove MOST of the floor clutter to try and save on lag
+    # minCount: 25
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 30
+    # maxCount: 40
+    # table: !type:NestedSelector
+      # tableId: SalvageScrapSpawnerValuable
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageTreasureSpawnerCommon
+    # perDungeon: true
+  # - !type:EntityTableDunGen
+    # minCount: 15
+    # maxCount: 25
+    # table: !type:NestedSelector
+      # tableId: SalvageEquipmentSpawnerCommon
+    # perDungeon: true # Coyote remove end: Remove MOST of the floor clutter to try and save on lag
   - !type:EntityTableDunGen
     minCount: 15
     maxCount: 20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
removes four of the floor clutter spawning loot tables, cutting out an average of around 400 item entities spawned per vgroid
reduces the max simultaneous vgroids from 3 to 2
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
the clutter is mostly useless junk that most people ignore and the actually useful stuff is mostly in the valuable table. So that stuff can stay since it's 15-20 items per table per dungeon and only 2 tables. Vs like 200 possible items from the other tables. technically this is a loot nerf but quite frankly I think people will appreciate the frame rate and lag improvements and most people didn't mind the clutter being absent entirely on expeds anyways.

reducing the max vgroids from 3 to 2 means that the 33% chance of a triple spawn means there is no longer a 33% chance the server will hitch like hell when the vgroids are deleted.
## Technical details
<!-- Summary of code changes for easier review. -->
changed some stuff in the individual vgroid files
changed some stuff in the dungeon spawner yml
im so sorry i try to write better ones but its 1am and I need to go to bed
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
summon the vgroids with command addgamerule bluespacedungeon[the one you want]
observe the new max spawn and the cleaner floors
marvel at it
realize that this is genuinely cleaner than some people's ships
weep
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: tank8673
- tweak: reduced max vgroid spawns from 3 to 2 to try and make big lag spikes less noticeable until we find a better optimization strategy for deletion
- tweak: reduced the amount of vgroid clutter that spawns to try and reduce lag from vgroids
