### PR TITLE
Stops vgroids from running grid appraisal if unnecessary

### DIFF
--- a/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
+++ b/Content.Server/_NF/StationEvents/Events/BluespaceErrorRule.cs
@@ -19,6 +19,7 @@ using Content.Server.StationEvents.Events;
 using Content.Server._NF.Station.Systems;
 using Content.Server._NF.StationEvents.Components;
 using Robust.Shared.EntitySerialization.Systems;
+using System.Linq;
 
 namespace Content.Server._NF.StationEvents.Events;
 
@@ -250,7 +251,8 @@ public sealed class BluespaceErrorRule : StationEventSystem<BluespaceErrorRuleCo
                     _transform.DetachEntity(mob.Entity.Owner, mob.Entity.Comp);
                 }
 
-                var gridValue = _pricing.AppraiseGrid(gridUid, null);
+                // Grid value is only needed if payout is required, and is computationally expensive. Skip if no payout accounts
+                var gridValue = component.RewardAccounts.Any() ? _pricing.AppraiseGrid(gridUid, null) : 0;
 
                 // Deletion has to happen before grid traversal re-parents players.
                 Del(gridUid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Vgroids and other event grids will no longer run grid appraisal prior to despawning unless there's actually an account set up to receive the money from it. (so vaults will still give a reward on despawn)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
10-30% speed up for deleting grid depending on size and number of entities

## Technical details
<!-- Summary of code changes for easier review. -->
.Any()

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn VGroid and wait for it to delete

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Vgroids will now cause 10-30% less lag when despawning

