### PR TITLE
Limit thief glove bonuses on sensitive slots

### DIFF
--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -32,13 +32,13 @@ namespace Content.Shared.Strip.Components
     public sealed class StrippingEnsnareButtonPressed : BoundUserInterfaceMessage;
 
     [ByRefEvent]
-    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : EntityEventArgs, IInventoryRelayEvent
+    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : EntityEventArgs, IInventoryRelayEvent // Coyote: Add string? slot = null, SlotFlags slotFlags = SlotFlags.NONE
     {
         public readonly TimeSpan InitialTime = initialTime;
         public float Multiplier = 1f;
         public TimeSpan Additive = TimeSpan.Zero;
         public bool Stealth = stealth;
-        public readonly string? Slot = slot;
+        public readonly string? Slot = slot; // Coyote
         public readonly SlotFlags SlotFlags = slotFlags;
 
         public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + Additive.Seconds, 0f));

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -32,12 +32,14 @@ namespace Content.Shared.Strip.Components
     public sealed class StrippingEnsnareButtonPressed : BoundUserInterfaceMessage;
 
     [ByRefEvent]
-    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false) : EntityEventArgs, IInventoryRelayEvent
+    public abstract class BaseBeforeStripEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : EntityEventArgs, IInventoryRelayEvent
     {
         public readonly TimeSpan InitialTime = initialTime;
         public float Multiplier = 1f;
         public TimeSpan Additive = TimeSpan.Zero;
         public bool Stealth = stealth;
+        public readonly string? Slot = slot;
+        public readonly SlotFlags SlotFlags = slotFlags;
 
         public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + Additive.Seconds, 0f));
 
@@ -51,7 +53,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeItemStrippedEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+    public sealed class BeforeItemStrippedEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags);
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the user.
@@ -60,7 +62,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeStripEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+    public sealed class BeforeStripEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags);
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the target.
@@ -69,7 +71,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeGettingStrippedEvent(TimeSpan initialTime, bool stealth = false) : BaseBeforeStripEvent(initialTime, stealth);
+    public sealed class BeforeGettingStrippedEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags);
 
     /// <summary>
     ///     Organizes the behavior of DoAfters for <see cref="StrippableSystem">.

--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -39,7 +39,7 @@ namespace Content.Shared.Strip.Components
         public TimeSpan Additive = TimeSpan.Zero;
         public bool Stealth = stealth;
         public readonly string? Slot = slot; // Coyote
-        public readonly SlotFlags SlotFlags = slotFlags;
+        public readonly SlotFlags SlotFlags = slotFlags; // Coyote: Track the targeted inventory slot flags.
 
         public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + Additive.Seconds, 0f));
 
@@ -53,7 +53,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeItemStrippedEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags);
+    public sealed class BeforeItemStrippedEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags); // Coyote: Forward slot context to item strip modifiers.
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the user.
@@ -62,7 +62,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeStripEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags);
+    public sealed class BeforeStripEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags); // Coyote: Forward slot context to the stripping actor.
 
     /// <summary>
     ///     Used to modify strip times. Raised directed at the target.
@@ -71,7 +71,7 @@ namespace Content.Shared.Strip.Components
     ///     This is also used by some stripping related interactions, i.e., interactions with items that are currently equipped by another player.
     /// </remarks>
     [ByRefEvent]
-    public sealed class BeforeGettingStrippedEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags);
+    public sealed class BeforeGettingStrippedEvent(TimeSpan initialTime, bool stealth = false, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) : BaseBeforeStripEvent(initialTime, stealth, slot, slotFlags); // Coyote: Forward slot context to the stripping target.
 
     /// <summary>
     ///     Organizes the behavior of DoAfters for <see cref="StrippableSystem">.

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Content.Shared.Strip.Components;
 
 /// <summary>
@@ -19,4 +21,11 @@ public sealed partial class ThievingComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("stealthy")]
     public bool Stealthy;
+
+    /// <summary>
+    /// Inventory slot names that should use default stripping behavior instead of thieving bonuses.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("blockedSlots")]
+    public HashSet<string> BlockedSlots = new();
 }

--- a/Content.Shared/Strip/Components/ThievingComponent.cs
+++ b/Content.Shared/Strip/Components/ThievingComponent.cs
@@ -26,6 +26,6 @@ public sealed partial class ThievingComponent : Component
     /// Inventory slot names that should use default stripping behavior instead of thieving bonuses.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("blockedSlots")]
+    [DataField("blockedSlots")] // Coyote: Configure slots that should ignore thieving bonuses.
     public HashSet<string> BlockedSlots = new();
 }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -208,7 +208,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             return;
         }
 
-        var (time, stealth) = GetStripTimeModifiers(user, target, held, slotDef.StripTime);
+        var (time, stealth) = GetStripTimeModifiers(user, target, held, slotDef.StripTime, slotDef.Name, slotDef.SlotFlags);
 
         if (!stealth)
             _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-insert",
@@ -299,7 +299,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             return;
         }
 
-        var (time, stealth) = GetStripTimeModifiers(user, target, item, slotDef.StripTime);
+        var (time, stealth) = GetStripTimeModifiers(user, target, item, slotDef.StripTime, slotDef.Name, slotDef.SlotFlags);
 
         if (!stealth)
         {
@@ -629,14 +629,14 @@ public abstract class SharedStrippableSystem : EntitySystem
     /// <summary>
     /// Modify the strip time via events. Raised directed at the item being stripped, the player stripping someone and the player being stripped.
     /// </summary>
-    public (TimeSpan Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid targetPlayer, EntityUid? targetItem, TimeSpan initialTime)
+    public (TimeSpan Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid targetPlayer, EntityUid? targetItem, TimeSpan initialTime, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE)
     {
-        var itemEv = new BeforeItemStrippedEvent(initialTime, false);
+        var itemEv = new BeforeItemStrippedEvent(initialTime, false, slot, slotFlags);
         if (targetItem != null)
             RaiseLocalEvent(targetItem.Value, ref itemEv);
-        var userEv = new BeforeStripEvent(itemEv.Time, itemEv.Stealth);
+        var userEv = new BeforeStripEvent(itemEv.Time, itemEv.Stealth, slot, slotFlags);
         RaiseLocalEvent(user, ref userEv);
-        var targetEv = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth);
+        var targetEv = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth, slot, slotFlags);
         RaiseLocalEvent(targetPlayer, ref targetEv);
         return (targetEv.Time, targetEv.Stealth);
     }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -208,7 +208,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             return;
         }
 
-        var (time, stealth) = GetStripTimeModifiers(user, target, held, slotDef.StripTime, slotDef.Name, slotDef.SlotFlags);
+        var (time, stealth) = GetStripTimeModifiers(user, target, held, slotDef.StripTime, slotDef.Name, slotDef.SlotFlags); // Coyote: Pass slot context so excluded slots use default stripping behavior.
 
         if (!stealth)
             _popupSystem.PopupEntity(Loc.GetString("strippable-component-alert-owner-insert",
@@ -299,7 +299,7 @@ public abstract class SharedStrippableSystem : EntitySystem
             return;
         }
 
-        var (time, stealth) = GetStripTimeModifiers(user, target, item, slotDef.StripTime, slotDef.Name, slotDef.SlotFlags);
+        var (time, stealth) = GetStripTimeModifiers(user, target, item, slotDef.StripTime, slotDef.Name, slotDef.SlotFlags); // Coyote: Pass slot context so excluded slots use default stripping behavior.
 
         if (!stealth)
         {
@@ -629,14 +629,14 @@ public abstract class SharedStrippableSystem : EntitySystem
     /// <summary>
     /// Modify the strip time via events. Raised directed at the item being stripped, the player stripping someone and the player being stripped.
     /// </summary>
-    public (TimeSpan Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid targetPlayer, EntityUid? targetItem, TimeSpan initialTime, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE)
+    public (TimeSpan Time, bool Stealth) GetStripTimeModifiers(EntityUid user, EntityUid targetPlayer, EntityUid? targetItem, TimeSpan initialTime, string? slot = null, SlotFlags slotFlags = SlotFlags.NONE) // Coyote: Accept slot context for slot-aware strip modifiers.
     {
-        var itemEv = new BeforeItemStrippedEvent(initialTime, false, slot, slotFlags);
+        var itemEv = new BeforeItemStrippedEvent(initialTime, false, slot, slotFlags); // Coyote: Preserve slot context when raising strip modifier events.
         if (targetItem != null)
             RaiseLocalEvent(targetItem.Value, ref itemEv);
-        var userEv = new BeforeStripEvent(itemEv.Time, itemEv.Stealth, slot, slotFlags);
+        var userEv = new BeforeStripEvent(itemEv.Time, itemEv.Stealth, slot, slotFlags); // Coyote: Preserve slot context for the stripping actor.
         RaiseLocalEvent(user, ref userEv);
-        var targetEv = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth, slot, slotFlags);
+        var targetEv = new BeforeGettingStrippedEvent(userEv.Time, userEv.Stealth, slot, slotFlags); // Coyote: Preserve slot context for the stripping target.
         RaiseLocalEvent(targetPlayer, ref targetEv);
         return (targetEv.Time, targetEv.Stealth);
     }

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -17,6 +17,9 @@ public sealed class ThievingSystem : EntitySystem
 
     private void OnBeforeStrip(EntityUid uid, ThievingComponent component, BeforeStripEvent args)
     {
+        if (args.Slot != null && component.BlockedSlots.Contains(args.Slot))
+            return;
+
         args.Stealth |= component.Stealthy;
         args.Additive -= component.StripTimeReduction;
     }

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -17,7 +17,7 @@ public sealed class ThievingSystem : EntitySystem
 
     private void OnBeforeStrip(EntityUid uid, ThievingComponent component, BeforeStripEvent args)
     {
-        if (args.Slot != null && component.BlockedSlots.Contains(args.Slot))
+        if (args.Slot != null && component.BlockedSlots.Contains(args.Slot)) // Coyote: Excluded slots fall back to default stripping behavior.
             return;
 
         args.Stealth |= component.Stealthy;

--- a/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
@@ -30,9 +30,11 @@
   - type: Thieving
     stripTimeReduction: 2
     stealthy: true
+    # Coyote Start: Slots blocked from thief's gloves bonus
     blockedSlots:
     - back
     - ears
     - id
     - jumpsuit
     - suitstorage
+    # Coyote End

--- a/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/specific.yml
@@ -30,3 +30,9 @@
   - type: Thieving
     stripTimeReduction: 2
     stealthy: true
+    blockedSlots:
+    - back
+    - ears
+    - id
+    - jumpsuit
+    - suitstorage


### PR DESCRIPTION
## About the PR
Limits the special thief glove effects so excluded slots fall back to default stripping behavior instead of being removed entirely.

Excluded slots:
- ears
- id
- jumpsuit
- back
- suitstorage

## Behavior
The gloves still hide the progress bar, speed up stripping, and suppress the victim message on allowed slots.
For the excluded slots, stripping still works, but uses normal/default behavior automatically.

## How to test
- Wear ClothingHandsChameleonThief
- Attempt to steal from an allowed slot and confirm thieving behavior still applies
- Attempt to steal from ears, id, jumpsuit, back, and suitstorage and confirm stripping still works but uses default behavior