### PR TITLE
Mini Vgroids for the weekdays

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_dungeons_events.yml
@@ -29,8 +29,8 @@
     groups:
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
-        minCount: 1 # Coyote add: make it vary from one
-        maxCount: 2 # Coyote add: to two instances
+        minCount: 4 # Coyote add: make it vary from four
+        maxCount: 6 # Coyote add: to six instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: &dungeonComponents
@@ -60,8 +60,8 @@
     groups:
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
-        minCount: 1 # Coyote add: make it vary from one
-        maxCount: 2 # Coyote add: to two instances
+        minCount: 4 # Coyote add: make it vary from four
+        maxCount: 6 # Coyote add: to six instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -77,8 +77,8 @@
     groups:
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
-        minCount: 1 # Coyote add: make it vary from one
-        maxCount: 2 # Coyote add: to two instances
+        minCount: 4 # Coyote add: make it vary from four
+        maxCount: 6 # Coyote add: to six instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -94,15 +94,15 @@
     groups:
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
-        minCount: 1 # Coyote add: make it vary from one
-        maxCount: 2 # Coyote add: to two instances
+        minCount: 4 # Coyote add: make it vary from four
+        maxCount: 6 # Coyote add: to six instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
         protos:
         - NFVGRoidChromite
 
-- type: entity
+- type: entity # This one doesn't spawn for some reason, and is a bit janky so its for the best it doesn't anyways
   id: BluespaceDungeonScrap
   parent: BluespaceDungeonBase
   categories: [ HideSpawnMenu ]
@@ -111,8 +111,8 @@
     groups:
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
-        minCount: 1 # Coyote add: make it vary from one
-        maxCount: 2 # Coyote add: to two instances
+        minCount: 4 # Coyote add: make it vary from four
+        maxCount: 6 # Coyote add: to six instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents
@@ -128,8 +128,8 @@
     groups:
       vgroid: !type:DungeonSpawnGroup
         nameDataset: NamesBorer
-        minCount: 1 # Coyote add: make it vary from one
-        maxCount: 2 # Coyote add: to two instances
+        minCount: 4 # Coyote add: make it vary from four
+        maxCount: 6 # Coyote add: to six instances
         minimumDistance: 2500 # Coyote add: 1500 -> 2500m
         maximumDistance: 3500 # Coyote add: 2500 -> 3500m
         addComponents: *dungeonComponents

--- a/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/basalt_vgroid.yml
@@ -43,7 +43,7 @@
       entityMask:
       - WallRockBasalt
       entity: NFBasaltElementalSpawner
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Ores
@@ -51,84 +51,84 @@
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltTin
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltCoal
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltQuartz
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltSalt
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltGold
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltSilver
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltPlasma
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltUranium
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: NFWallBasaltCobblebrick
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 6
       maxGroupSize: 16
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltArtifactFragment
-      count: 25
+      count: 13 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 3
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: WallRockBasaltDiamond
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       entityMask:
       - WallRockBasalt
       entity: NFWallRockBasaltBluespace
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Decoration
@@ -144,7 +144,7 @@
       tileMask:
       - FloorBasalt
       entity: SpawnMobMercenaryEVAT3
-      count: 5
+      count: 2 # Coyote: mobs in the rocks halved-ish
       minGroupSize: 1
       maxGroupSize: 1
 
@@ -153,7 +153,7 @@
   id: NFVGRoidBlobBasalt
   layers:
   - !type:NoiseDistanceDunGen
-    size: 272, 272
+    size: 200, 200 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
       blendWeight: 0.80
     layers:
@@ -173,7 +173,7 @@
   maxOffset: 60
   layers:
   - !type:NoiseDistanceDunGen
-    size: 150, 150
+    size: 100, 100 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
     layers:
     - tile: FloorBasalt
@@ -199,8 +199,8 @@
 - type: dungeonConfig
   id: NFVGRoidExteriorDungeonsBasalt
   reserveTiles: true
-  minCount: 4
-  maxCount: 5
+  minCount: 1 # Coyote change: dungeons to 1-2 instead of 2-3
+  maxCount: 2 # Coyote change: dungeons to 1-2 instead of 2-3
   layers:
   - !type:ExteriorDunGen
     proto: NFLavaMercenary
@@ -245,8 +245,8 @@
     maxCount: 6
     contents: SpawnMobMercenaryEVAT1Table
   - !type:MobsDunGen
-    minCount: 8
-    maxCount: 15
+    minCount: 4 # Coyote: merc quantity reduction
+    maxCount: 8 # Coyote: merc quantity reduction
     contents: SpawnMobMercenaryEVAT2Table
   - !type:MobsDunGen
     minCount: 1
@@ -263,7 +263,7 @@
   table: !type:GroupSelector
     children:
     - id: SpawnMobMercenaryEVAT1
-      amount: 2
+      amount: 1 #Coyote: merc quantity reduction
 
 - type: entityTable
   id: SpawnMobMercenaryEVAT2Table

--- a/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/cave_vgroid.yml
@@ -43,7 +43,7 @@
       entityMask:
       - WallRock
       entity: NFRockElementalSpawner
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Ores
@@ -51,84 +51,84 @@
       entityMask:
       - WallRock
       entity: WallRockTin
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockCoal
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockQuartz
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockSalt
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockGold
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockSilver
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockPlasma
-      count: 35
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockUranium
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: NFWallCobblebrick
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 6
       maxGroupSize: 16
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockArtifactFragment
-      count: 25
+      count: 13 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 3
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockDiamond
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: NFWallRockBluespace
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Decoration
@@ -144,7 +144,7 @@
       tileMask:
       - FloorCaveDrought
       entity: SpawnMobExplorerEVAT3
-      count: 5
+      count: 2 # Coyote: mobs in the rocks halved-ish
       minGroupSize: 1
       maxGroupSize: 1
 
@@ -153,7 +153,7 @@
   id: NFVGRoidBlobCave
   layers:
   - !type:NoiseDistanceDunGen
-    size: 272, 272
+    size: 200, 200 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
       blendWeight: 0.80
     layers:
@@ -173,7 +173,7 @@
   maxOffset: 60
   layers:
   - !type:NoiseDistanceDunGen
-    size: 150, 150
+    size: 100, 100 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
     layers:
     - tile: FloorCaveDrought
@@ -199,8 +199,8 @@
 - type: dungeonConfig
   id: NFVGRoidExteriorDungeonsCave
   reserveTiles: true
-  minCount: 4
-  maxCount: 5
+  minCount: 1 # Coyote change: dungeons to 1-2 instead of 2-3
+  maxCount: 2 # Coyote change: dungeons to 1-2 instead of 2-3
   layers:
   - !type:ExteriorDunGen
     proto: NFSalvageOutpost

--- a/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/chromite_vgroid.yml
@@ -43,7 +43,7 @@
       entityMask:
       - WallRockChromite
       entity: NFChromiteElementalSpawner
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Ores
@@ -51,84 +51,84 @@
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteTin
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteCoal
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteQuartz
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteSalt
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteGold
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteSilver
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromitePlasma
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteUranium
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: NFWallChromiteCobblebrick
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 6
       maxGroupSize: 16
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteArtifactFragment
-      count: 25
+      count: 13 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 3
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: WallRockChromiteDiamond
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       entityMask:
       - WallRockChromite
       entity: NFWallRockChromiteBluespace
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Decoration
@@ -144,7 +144,7 @@
       tileMask:
       - FloorChromite
       entity: SpawnMobBloodCultLeech
-      count: 5
+      count: 2 # Coyote: mobs in the rocks halved-ish
       minGroupSize: 1
       maxGroupSize: 1
 
@@ -153,7 +153,7 @@
   id: NFVGRoidBlobChromite
   layers:
   - !type:NoiseDistanceDunGen
-    size: 272, 272
+    size: 200, 200 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
       blendWeight: 0.80
     layers:
@@ -173,7 +173,7 @@
   maxOffset: 60
   layers:
   - !type:NoiseDistanceDunGen
-    size: 150, 150
+    size: 100, 100 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
     layers:
     - tile: FloorChromite
@@ -199,8 +199,8 @@
 - type: dungeonConfig
   id: NFVGRoidExteriorDungeonsChromite
   reserveTiles: true
-  minCount: 4
-  maxCount: 5
+  minCount: 1 # Coyote change: dungeons to 1-2 instead of 2-3
+  maxCount: 2 # Coyote change: dungeons to 1-2 instead of 2-3
   layers:
   - !type:ExteriorDunGen
     proto: NFVirologyLab

--- a/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/scrap_vgroid.yml
@@ -41,7 +41,7 @@
       entityMask:
       - NFWallRockScrapPile
       entity: NFAsteroidScrapBotWallSpawner # Wall that spawn mobs
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Ores
@@ -49,84 +49,84 @@
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileIron
-      count: 30
+      count: 15 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileCoal
-      count: 30
+      count: 15 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileQuartz
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileSalt
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileGold
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileSilver
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPilePlasma
-      count: 20
+      count: 10 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileUranium
-      count: 20
+      count: 10 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: WallSolidRust
-      count: 70
+      count: 35 # Coyote: rock spawns halved-ish
       minGroupSize: 6
       maxGroupSize: 16
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileArtifactFragment
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 3
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileDiamond
-      count: 5
+      count: 3 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       entityMask:
       - NFWallRockScrapPile
       entity: NFWallRockScrapPileBluespace
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Decoration
@@ -158,7 +158,7 @@
   id: NFVGRoidBlobScrap
   layers:
   - !type:NoiseDistanceDunGen
-    size: 272, 272
+    size: 200, 200 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
       blendWeight: 0.80
     layers:
@@ -185,8 +185,8 @@
 - type: dungeonConfig
   id: NFVGRoidExteriorDungeonsScrap
   reserveTiles: true
-  minCount: 4
-  maxCount: 5
+  minCount: 1 # Coyote change: dungeons to 1-2 instead of 2-3
+  maxCount: 2 # Coyote change: dungeons to 1-2 instead of 2-3
   layers:
   - !type:ExteriorDunGen
     proto: NFSalvageOutpost

--- a/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/snow_vgroid.yml
@@ -43,7 +43,7 @@
       entityMask:
       - WallRockSnow
       entity: NFSnowElementalSpawner
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Ores
@@ -51,84 +51,84 @@
       entityMask:
       - WallRockSnow
       entity: WallRockSnowTin
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowCoal
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowQuartz
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowSalt
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowGold
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowSilver
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowPlasma
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowUranium
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: NFWallSnowCobblebrick
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 6
       maxGroupSize: 16
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowArtifactFragment
-      count: 25
+      count: 13 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 3
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: WallRockSnowDiamond
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       entityMask:
       - WallRockSnow
       entity: NFWallRockSnowBluespace
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Decoration
@@ -174,7 +174,7 @@
   id: NFVGRoidBlobSnow
   layers:
   - !type:NoiseDistanceDunGen
-    size: 272, 272
+    size: 200, 200 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
       blendWeight: 0.80
     layers:
@@ -194,7 +194,7 @@
   maxOffset: 60
   layers:
   - !type:NoiseDistanceDunGen
-    size: 150, 150
+    size: 100, 100 # Coyote change: reduces max size due to increased spawn cap
     distanceConfig: !type:DunGenEuclideanSquaredDistance
     layers:
     - tile: FloorSnow
@@ -220,8 +220,8 @@
 - type: dungeonConfig
   id: NFVGRoidExteriorDungeonsSnow
   reserveTiles: true
-  minCount: 4
-  maxCount: 5
+  minCount: 1 # Coyote change: dungeons to 1-2 instead of 2-3
+  maxCount: 2 # Coyote change: dungeons to 1-2 instead of 2-3
   layers:
   - !type:ExteriorDunGen
     proto: NFSnowyLabs

--- a/Resources/Prototypes/_NF/Procedural/zombie_vgroid.yml
+++ b/Resources/Prototypes/_NF/Procedural/zombie_vgroid.yml
@@ -38,7 +38,7 @@
       entityMask:
       - WallRock
       entity: NFRockElementalSpawner
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Ores
@@ -46,84 +46,84 @@
       entityMask:
       - WallRock
       entity: WallRockTin
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockCoal
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockQuartz
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 10
       maxGroupSize: 15
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockSalt
-      count: 50
+      count: 25 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockGold
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockSilver
-      count: 40
+      count: 20 # Coyote: rock spawns halved-ish
       minGroupSize: 8
       maxGroupSize: 12
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockPlasma
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockUranium
-      count: 35
+      count: 18 # Coyote: rock spawns halved-ish
       minGroupSize: 4
       maxGroupSize: 8
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: NFWallCobblebrick
-      count: 100
+      count: 50 # Coyote: rock spawns halved-ish
       minGroupSize: 6
       maxGroupSize: 16
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockArtifactFragment
-      count: 25
+      count: 13 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 3
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: WallRockDiamond
-      count: 15
+      count: 8 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 2
     - !type:OreDunGen
       entityMask:
       - WallRock
       entity: NFWallRockBluespace
-      count: 10
+      count: 5 # Coyote: rock spawns halved-ish
       minGroupSize: 1
       maxGroupSize: 1
     # Mobs
@@ -131,7 +131,7 @@
       tileMask:
       - FloorCaveDrought
       entity: NFSpawnMobZombie
-      count: 5
+      count: 3 # Coyote: mobs in the rocks halved-ish
       minGroupSize: 1
       maxGroupSize: 1
 
@@ -149,8 +149,8 @@
 - type: dungeonConfig
   id: NFVGRoidExteriorDungeonsVirologyLabZombies
   reserveTiles: true
-  minCount: 4
-  maxCount: 5
+  minCount: 1 # Coyote change: dungeons to 1-2 instead of 2-3
+  maxCount: 2 # Coyote change: dungeons to 1-2 instead of 2-3
   layers:
   - !type:ExteriorDunGen
     proto: NFVirologyLab


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Reduces vgroid size substantially, current amount of vgroids should have less tiles and be overall more "condensed" to the stuff people care about
Adjusted the merc vgroid to be less insane because 30 enemies per dungeon was actually more numerous than ZOMBIES ffs.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
New vgroid spawns are 4-6 vgroids per rotation. Each vgroid has about half the ores, and 1-2 dungeons compared to a stock vgroid. With the persistence until you leave the grid, you could easily claim a side or a whole vgroid and salvage it until you're content with what you've taken rather than having to rush rush rush. This should hopefully provide a "sorta exped" type experience. And people won't be dejected about being slightly late to vgroids and not finding a place to enter in from. Cuz now there are 4-6 of em to try. And people who are REALLY loot hungry will be sticking around on theirs for longer than the event lasts so a new one might pop in the meantime.

Merc vgroids have like 3x the enemy count for a fraction of the reward. also that many entities could not have been good for lag. So that's been cut down a bit. Should be 10-18

Promise I'm working on the punk and dino vgroids (and will do the other enemy types too, and get the scrap vgroid back in the pool) but 2 year old wizden uncommented code makes doing virtually anything a harder task than it needs to be about half the time ;-;
## Technical details
<!-- Summary of code changes for easier review. -->
honestly there's a lot of repeats but its mostly numerical tweaks across the vgroid folders
soz its midnight and typing out all these changes would kill me lmao
## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
addgamerule bluespacedungeonbasalt
observe
waow
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
i forgor to take some pics but the roids are cute now
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that AI tools were not used in generating the material in this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: tank8673
- tweak: Utilizes mini vgroids for testing this week.
