### PR TITLE
Hard stun chem adjustment

### DIFF
--- a/Resources/Locale/en-US/reagents/generic.ftl
+++ b/Resources/Locale/en-US/reagents/generic.ftl
@@ -9,3 +9,10 @@ generic-reagent-effect-parched = You feel parched.
 generic-reagent-effect-thirsty = You feel thirsty.
 generic-reagent-effect-sick = You feel sick after consuming that...
 generic-reagent-effect-slicing-insides = You feel an incredibly sharp pain in your gut!
+
+# coyote edit
+generic-reagent-effect-static = You feel your hair stand on end.
+generic-reagent-effect-prickle = You feel your skin prickling with static charge.
+generic-reagent-effect-peaceful = You feel peaceful.
+generic-reagent-effect-harmless = You feel like you don't even wanna hurt a fly.
+generic-reagent-effect-harmony = You feel at peace with the universe.

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -164,8 +164,15 @@
   metabolisms:
     Poison:
       effects:
-      - !type:Electrocute
-        probability: 0.35
+      - !type:PopupMessage  # Coyote edit: this chem has been castrated until it is no longer a hard shutdown
+        type: Local
+        visualType: MediumCaution
+        messages:
+        - "generic-reagent-effect-static"
+        - "generic-reagent-effect-prickle"
+        probability: 0.2
+#      - !type:Electrocute
+#        probability: 0.35
 
 - type: reagent
   id: Razorium
@@ -341,21 +348,21 @@
         showInGuidebook: true
         force: true
         probability: 0.5
-      - !type:Polymorph
-        prototype: ArtifactLizard # Does the same thing as the original YML I made for this reagent.
-        conditions:
-        # - !type:OrganType # Frontier
-        #   type: Animal # Frontier
-        #   shouldHave: false # Frontier
-        - !type:NFIsHumanoid # Frontier
-        - !type:ReagentThreshold
-          min: 50
-      - !type:AdjustReagent
-        reagent: JuiceThatMakesYouWeh
-        amount: -20
-        conditions:
-        - !type:ReagentThreshold
-          min: 50
+#      - !type:Polymorph  # Coyote edit: no forced TF
+#        prototype: ArtifactLizard # Does the same thing as the original YML I made for this reagent.
+#        conditions:
+#        # - !type:OrganType # Frontier
+#        #   type: Animal # Frontier
+#        #   shouldHave: false # Frontier
+#        - !type:NFIsHumanoid # Frontier
+#        - !type:ReagentThreshold
+#          min: 50
+#      - !type:AdjustReagent
+#        reagent: JuiceThatMakesYouWeh
+#        amount: -20
+#        conditions:
+#        - !type:ReagentThreshold
+#          min: 50
 
 - type: reagent
   id: JuiceThatMakesYouHew
@@ -375,18 +382,18 @@
         showInGuidebook: true
         force: true
         probability: 0.5
-      - !type:Polymorph
-        prototype: ArtifactLizard
-        conditions:
-        # - !type:OrganType # Frontier
-        #   type: Animal # Frontier
-        #   shouldHave: false # Frontier
-        - !type:NFIsHumanoid # Frontier
-        - !type:ReagentThreshold
-          min: 50
-      - !type:AdjustReagent
-        reagent: JuiceThatMakesYouHew
-        amount: -20
-        conditions:
-        - !type:ReagentThreshold
-          min: 50
+#      - !type:Polymorph  # Coyote edit: no forced TF
+#        prototype: ArtifactLizard
+#        conditions:
+#        # - !type:OrganType # Frontier
+#        #   type: Animal # Frontier
+#        #   shouldHave: false # Frontier
+#        - !type:NFIsHumanoid # Frontier
+#        - !type:ReagentThreshold
+#          min: 50
+#      - !type:AdjustReagent
+#        reagent: JuiceThatMakesYouHew
+#        amount: -20
+#        conditions:
+#        - !type:ReagentThreshold
+#          min: 50

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -296,15 +296,22 @@
   metabolisms:
     Narcotic:
       effects:
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nocturine
-          min: 8
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
+      - !type:Emote
+        emote: Yawn
+        showInChat: true
+        probability: 0.1
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.65
+        sprintSpeedModifier: 0.65
+#      - !type:GenericStatusEffect   # Coyote edit: this chem has been castrated until it is no longer a hard shutdown
+#        conditions:
+#        - !type:ReagentThreshold
+#          reagent: Nocturine
+#          min: 8
+#        key: ForcedSleep
+#        component: ForcedSleeping
+#        refresh: false
+#        type: Add
 
 - type: reagent
   id: MuteToxin

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -63,12 +63,12 @@
       - !type:MovespeedModifier
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
-      - !type:GenericStatusEffect
-        key: Drowsiness
-        component: Drowsiness
-        time: 4
-        type: Add
-        refresh: false
+#      - !type:GenericStatusEffect   # Coyote edit: this chem has been castrated until it is no longer a hard shutdown
+#        key: Drowsiness
+#        component: Drowsiness
+#        time: 4
+#        type: Add
+#        refresh: false
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -323,6 +323,7 @@
   color: "#6b0007"
   metabolisms:
     Poison:
+      metabolismRate: 3.00 # Coyote edit, brings to the level of other severe acids
       effects:
       - !type:HealthChange
         damage:
@@ -558,7 +559,7 @@
             Poison: 0.06
 
 - type: reagent
-  id: Pax
+  id: Pax # Coyote edit: castrated to prevent instant knockouts. needs a slower buildup of 20-30 seconds or more
   name: reagent-name-pax
   group: Narcotics
   desc: reagent-desc-pax
@@ -567,11 +568,19 @@
   metabolisms:
     Poison:
       effects:
-      - !type:GenericStatusEffect
-        key: Pacified
-        component: Pacified
-        type: Add
-        time: 4
+      - !type:PopupMessage
+        type: Local
+        visualType: MediumCaution
+        messages:
+        - "generic-reagent-effect-peaceful"
+        - "generic-reagent-effect-harmless"
+        - "generic-reagent-effect-harmony"
+        probability: 0.2
+#      - !type:GenericStatusEffect
+#        key: Pacified
+#        component: Pacified
+#        type: Add
+#        time: 4
 
 - type: reagent
   id: Honk
@@ -668,8 +677,15 @@
   metabolisms:
     Poison:
       effects:
-      - !type:Electrocute
-        probability: 0.8
+      - !type:PopupMessage  # Coyote edit: this chem has been castrated until it is no longer a hard shutdown
+        type: Local
+        visualType: MediumCaution
+        messages:
+        - "generic-reagent-effect-static"
+        - "generic-reagent-effect-prickle"
+        probability: 0.4
+#      - !type:Electrocute
+#        probability: 0.8
 
 - type: reagent
   id: Lipolicide

--- a/Resources/Prototypes/_NF/Reagents/biological.yml
+++ b/Resources/Prototypes/_NF/Reagents/biological.yml
@@ -63,18 +63,18 @@
           showInChat: true
           force: true
           probability: 0.18
-        - !type:Polymorph
-          prototype: ArtifactMonkey
-          conditions:
-            - !type:NFIsHumanoid
-            - !type:ReagentThreshold
-              min: 50
-        - !type:AdjustReagent
-          reagent: Primatine
-          amount: -20
-          conditions:
-            - !type:ReagentThreshold
-              min: 50
+#        - !type:Polymorph # Coyote edit: no forced TF
+#          prototype: ArtifactMonkey
+#          conditions:
+#            - !type:NFIsHumanoid
+#            - !type:ReagentThreshold
+#              min: 50
+#        - !type:AdjustReagent
+#          reagent: Primatine
+#          amount: -20
+#          conditions:
+#            - !type:ReagentThreshold
+#              min: 50
         - !type:GenericStatusEffect
           key: Stutter
           component: ScrambledAccent


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Removes the hard combat shutdown of a number of chemicals, increases metabolism speed of lexorin, and removes forced transformation from multiple chemicals

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chemical weapons are soon to be allowed per server policy, so instant fight ending effects must be removed, period. nerfing the chemical is far easier than making it impossible to get. Lexorin did triple the damage of any other toxin so has been altered to fit in alongside the potent fast acting acids, still quite respectable

## Technical details
<!-- Summary of code changes for easier review. -->
pax, licoxide, and tazinide no longer do anything but flavor messages. there is no current compromise that works for those chems.
nocturine and chloral hydrate no longer put the subject to sleep, but apply a slowdown.
primatine, jucethatmakesyouweh, and juicethatmakesyouhew no longer TF.
Lexorin has triple its former metabolism speed, same as acids.

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
spawn person and place chemicals inside of
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
