### PR TITLE
Lowers base RPI income

### DIFF
--- a/Resources/Prototypes/_CS/RPI stuff/RpiTaxBrackets.yml
+++ b/Resources/Prototypes/_CS/RPI stuff/RpiTaxBrackets.yml
@@ -1,7 +1,7 @@
 - type: rpiTaxBracket
   id: rpiTaxBracketDefault
   cashThreshold: -1
-  judgementPointPayout: 80
+  judgementPointPayout: 40
   deathPenalty: 0.10
   deepFriedPenalty: 0.25
   journalismDat:
@@ -31,7 +31,7 @@
 - type: rpiTaxBracket
   id: rpiTaxBracketBroke
   cashThreshold: 50000
-  judgementPointPayout: 300
+  judgementPointPayout: 150
   deathPenalty: 0.01
   deepFriedPenalty: 0.10
   journalismDat:
@@ -61,7 +61,7 @@
 - type: rpiTaxBracket
   id: rpiTaxBracketEstablished
   cashThreshold: 250000
-  judgementPointPayout: 200
+  judgementPointPayout: 100
   deathPenalty: 0.05
   deepFriedPenalty: 0.15
   journalismDat:
@@ -91,7 +91,7 @@
 - type: rpiTaxBracket
   id: rpiTaxBracketWealthy
   cashThreshold: 500000
-  judgementPointPayout: 100
+  judgementPointPayout: 50
   deathPenalty: 0.075
   deepFriedPenalty: 0.2
   journalismDat:


### PR DESCRIPTION
## About the PR
Cuts RPI income by around 25-50%, based on current bank.

Also lowers the capturebait/pirate w/ capturebait multiplier. It was set to 10, and most people were either capturebait or pirates!

## Why / Balance
Polls have shown that RPI is a bit nuts.

## Technical details
<!-- Summary of code changes for easier review. -->

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Nerfed RPI and capturebait cus it was pretty ridonculous.
