### PR TITLE
Fixes Shelegs being injectable with hyposprays

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
@@ -116,7 +116,8 @@ public sealed class HypospraySystem : SharedHypospraySystem
 
         var doAfterDelay = TimeSpan.FromSeconds(0);
 
-        if (!entity.Comp.BypassBlockInjection && TryComp<BlockInjectionComponent>(target, out var blockComponent)) // DeltaV
+        if (!entity.Comp.BypassBlockInjection && TryComp<BlockInjectionComponent>(target, out var blockComponent) // DeltaV
+            && blockComponent.BlockHypospray) //Coyote
         {
             var msg = Loc.GetString($"injector-component-deny-user",
                 ("target", Identity.Entity(target, EntityManager)));

--- a/Content.Shared/_DV/Chemistry/Components/BlockInjectionComponent.cs
+++ b/Content.Shared/_DV/Chemistry/Components/BlockInjectionComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class BlockInjectionComponent : Component
     /// If true, this component will block injections from hypospray.
     /// </summary>
     [DataField]
-    public bool BlockHypospray;
+    public bool BlockHypospray = false; //Coyote: set to false by default
 
     /// <summary>
     /// If true, this component will block injections from projectile.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -24,6 +24,7 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice
@@ -65,6 +66,7 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 0.5
   - type: Appearance
@@ -105,6 +107,7 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 0.5
 
@@ -678,6 +681,7 @@
     heldOnly: true # Allow examination only when held in hand.
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/_CS/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_CS/Entities/Objects/Specific/Medical/healing.yml
@@ -327,6 +327,7 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice
@@ -363,6 +364,7 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote; Shelegs cannot be injected
   - type: UseDelay
     delay: 0.75
   - type: StaticPrice

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Medical/hypospray.yml
@@ -24,6 +24,7 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 2.5
   - type: StaticPrice
@@ -424,6 +425,7 @@
   - type: Hypospray
     onlyAffectsMobs: false
     injectOnly: true
+    bypassBlockInjection: false #Coyote: Shelegs cannot be injected
   - type: UseDelay
     delay: 0.5
   - type: Appearance


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Fixes the hypospray to work properly with Shelegs. You can no longer inject Shelegs with hyposprays as intended.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Shelegs have the downside that they cannot be injected in any way; no syringe, no hypospray, no hypodart, no hypopen. This was not the case; syringes didn't work, but all kinds of hypos did.

## Technical details
<!-- Summary of code changes for easier review. -->
All hyposprays were set to bypass injection blocking by default; all of them were given one line to make this no longer the case. (Reason why they were all changed this way instead of just changing the default value is because of autoinjectors; they share the same code with hyposprays, and there are much more of them than hypos. Should they too be restricted is something for another time)
Hypospray component itself received a minor tweak; it previously checked only if the target had the blockinjection -component, not checking for the "blockhypospray" variable at all. The check was very slightly tweaked to check for that variable instead.
BlockInjection component was also tweaked by a tiny bit to have "block hypospray" set to false by default (previously no value)

## How to test
<!-- Describe a procedure to test this feature, along with expected output/behavior. -->
Spawn Sheleg, Chitinid, and any other playable species
Spawn Hypospray
Fill hypospray
Try to inject the three test subjects
Sheleg should ignore injection, chitinid and third guy should be injected
Repeat test with hypopen, other hyposprays, and hypodarts. Results should be the same as first test.
Repeat test with syringe in place of hypospray
Syringe cannot inject sheleg or chitinid (no changes here)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/8428395a-0286-4c17-bf05-7700a1d6262c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Tweaks the BlockInjectionComponent.blockHypospray to be false by default.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixes Shelegs being able to be injected with hyposprays.
- fix: Fixed a minor oversight in hypospray code.
