### PR TITLE
Bugfix: Ssd Asphyxiation Check

### DIFF
--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -20,7 +20,8 @@ using JetBrains.Annotations;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
-using Content.Shared.SSDIndicator; // Coyote: needed to check if something has the component.
+using Content.Shared.SSDIndicator; // Coyote
+using Content.Shared.Mind.Components; // Coyote
 
 namespace Content.Server.Body.Systems;
 
@@ -78,8 +79,10 @@ public sealed class RespiratorSystem : EntitySystem
             if (_mobState.IsDead(uid))
                 continue;
 
-            // Coyote
-            if (TryComp<SSDIndicatorComponent>(uid, out var ssd) && ssd.IsSSD)
+            // Coyote: Prevents SSD clients that have a mind associated to them from breathing to prevent offline asphyx deaths.
+            if (TryComp<SSDIndicatorComponent>(uid, out var ssd) && ssd.IsSSD
+             && TryComp<MindContainerComponent>(uid, out var mindContComp)
+              && mindContComp.HasMind)
                 continue;
             // Coyote End
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the issue with humanoid bounty npcs not breathing.

## Why / Balance
The new check takes into account if a character has a player mind associated with them, allowing any humanoid mobs that aren't controlled by a player to asphyxiate and die in the right conditions. Previously, this was not the case.

## Technical details
Just adds another check to the loop.

## How to test
Spawn an empty air can and a mask, asphyxiate yourself, disconnect, connect with a different client, observe that your character is no longer asphyxiating. Do the same to a medical bounty NPC, verify that they asphyxiate regardless, since they did not have a player mind associated to them.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: medical bounty humanoids are once again affected by asphyxiation.
