### PR TITLE
Fix Borg stripping and module whitelist removal

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -17,6 +17,7 @@
       collection: MetalThud
   - type: CombatMode
   - type: NoSlip
+  - type: Stripping
   - type: StaticPrice
     price: 1250
   - type: Fixtures

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -17,7 +17,7 @@
       collection: MetalThud
   - type: CombatMode
   - type: NoSlip
-  - type: Stripping
+  - type: Stripping # Coyote: Let borgs strip people
   - type: StaticPrice
     price: 1250
   - type: Fixtures

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -7,10 +7,6 @@
 
   # Functional
   extraModuleCount: 5
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleScience #until sciborgs are added
 
   defaultModules:
   - BorgModuleTool
@@ -42,10 +38,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleEngineering
 
   defaultModules:
   - BorgModuleTool
@@ -79,10 +71,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleCargo
 
   defaultModules:
   - BorgModuleTool
@@ -117,10 +105,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleJanitor
 
   defaultModules:
   - BorgModuleTool
@@ -154,10 +138,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleMedical
 
   defaultModules:
   - BorgModuleTool
@@ -208,10 +188,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleService
 
   defaultModules:
   - BorgModuleTool
@@ -251,10 +227,6 @@
 
   # Functional
   extraModuleCount: 5
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleScience
 
   defaultModules:
   - BorgModuleTool
@@ -293,10 +265,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleEngineering
 
   defaultModules:
   - BorgModuleTool
@@ -338,10 +306,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleCargo
 
   defaultModules:
   - BorgModuleTool
@@ -383,10 +347,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleJanitor
 
   defaultModules:
   - BorgModuleTool
@@ -427,10 +387,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleMedical
 
   defaultModules:
   - BorgModuleTool
@@ -486,10 +442,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleService
 
   defaultModules:
   - BorgModuleTool
@@ -536,10 +488,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleCargo
 
   defaultModules:
   - BorgModuleTool
@@ -581,10 +529,6 @@
 
   # Functional
   extraModuleCount: 3
-  moduleWhitelist:
-    tags:
-    - BorgModuleGeneric
-    - BorgModuleCargo
 
   defaultModules:
   - BorgModuleTool

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -7,6 +7,12 @@
 
   # Functional
   extraModuleCount: 5
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleScience #until sciborgs are added
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -38,6 +44,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleEngineering
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -71,6 +83,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleCargo
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -105,6 +123,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleJanitor
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -138,6 +162,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleMedical
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -188,6 +218,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleService
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -227,6 +263,12 @@
 
   # Functional
   extraModuleCount: 5
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleScience #until sciborgs are added
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -265,6 +307,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleEngineering
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -306,6 +354,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleCargo
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -347,6 +401,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleJanitor
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -387,6 +447,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleMedical
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -442,6 +508,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleService
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -488,6 +560,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleCargo
+# End Coyote
 
   defaultModules:
   - BorgModuleTool
@@ -529,6 +607,12 @@
 
   # Functional
   extraModuleCount: 3
+# Coyote: Remove borg module whitelist
+#  moduleWhitelist:
+#    tags:
+#    - BorgModuleGeneric
+#    - BorgModuleCargo
+# End Coyote
 
   defaultModules:
   - BorgModuleTool


### PR DESCRIPTION
## About the PR
Allows Borgs to strip players/mobs, which can already be done by other players.
Removed the module whitelist on Borgs, so you can put any module in any type.

## Why / Balance
Normal players can already strip players/mobs fine, but anyone playing as a Borg is currently unable, meaning medical borgs can't remove hardsuits for cryo, as well as any other use of stripping players.

Currently Borg players are locked to the specific body type they made unless they have multiple bodies and someone to switch them in and out. Removing the module whitelist means you can have one body that can perform multiple functions at some level.
This does open up an opportunity for powergaming by having an "optimal" set of modules for specific things, but I feel this would fall under the normal powergaming rules rather than being a hard restriction.

## Technical details
Added the StrippingComponent to the BaseBorgChassisNotIonStormable entity. This was chosen as it's the first borg entity above BaseMob, which is the same layer that the StrippingComponent sits for regular players.
Removed the moduleWhitelist array from all of the borg types.

## How to test
Stripping:
 - Spawn in as borg
 - Go up to a mob and use the "strip" action
 - Observe

Module Whitelist:
 - Spawn in as borg
 - Select body type
 - Open access hatch
 - Swap to controlling other mob
 - Try to install any borg module

## Media
<img width="689" height="424" alt="image" src="https://github.com/user-attachments/assets/2b72e57f-66b8-4b8c-9ac9-3ca77776f48b" />
<img width="605" height="570" alt="image" src="https://github.com/user-attachments/assets/54292a36-d4aa-4ce3-bf17-9f0c7bc1717a" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Borgs of any type can take modules of any type.
- fix: Borgs can strip people now.
