### PR TITLE
Give Borgs backpacks

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -13,7 +13,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.PDA;
-using Content.Shared.Storage;
+using Content.Shared.Storage; //Coyote
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -283,7 +283,7 @@ public sealed class ClientClothingSystem : ClothingSystem
             RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slot, revealedLayers), true);
             return;
         }
-        // Borgs can still carry a PDA in the id slot, but should not render the PDA sprite on their chassis.
+        // Coyote: Hide the backpacks on a borg, the sprites don't line up so we just don't render them.
         if (slot == "back" && HasComp<BorgChassisComponent>(equipee) && HasComp<StorageComponent>(equipment))
         {
             RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slot, revealedLayers), true);

--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.PDA;
+using Content.Shared.Storage;
 using Content.Shared.Silicons.Borgs.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -275,13 +276,20 @@ public sealed class ClientClothingSystem : ClothingSystem
             revealedLayers = new();
             inventorySlots.VisualLayerKeys[slot] = revealedLayers;
         }
-
+        // Coyote: Borgs have a different body, so don't draw specific equipment
         // Borgs can still carry a PDA in the id slot, but should not render the PDA sprite on their chassis.
         if (slot == "id" && HasComp<BorgChassisComponent>(equipee) && HasComp<PdaComponent>(equipment))
         {
             RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slot, revealedLayers), true);
             return;
         }
+        // Borgs can still carry a PDA in the id slot, but should not render the PDA sprite on their chassis.
+        if (slot == "back" && HasComp<BorgChassisComponent>(equipee) && HasComp<StorageComponent>(equipment))
+        {
+            RaiseLocalEvent(equipment, new EquipmentVisualsUpdatedEvent(equipee, slot, revealedLayers), true);
+            return;
+        }
+        // Coyote End
 
         var ev = new GetEquipmentVisualsEvent(equipee, slot);
         RaiseLocalEvent(equipment, ev);

--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -17,6 +17,7 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+# Coyote: Give borgs the ability to wear a backpack
   - name: back
     slotTexture: back
     fullTextureName: template_small
@@ -47,6 +48,7 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+# Coyote: Give borgs the ability to wear a backpack
   - name: back
     slotTexture: back
     fullTextureName: template_small
@@ -77,6 +79,7 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+# Coyote: Give borgs the ability to wear a backpack
   - name: back
     slotTexture: back
     fullTextureName: template_small
@@ -108,6 +111,7 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+# Coyote: Give borgs the ability to wear a backpack
   - name: back
     slotTexture: back
     fullTextureName: template_small

--- a/Resources/Prototypes/InventoryTemplates/borg.yml
+++ b/Resources/Prototypes/InventoryTemplates/borg.yml
@@ -17,6 +17,15 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+  - name: back
+    slotTexture: back
+    fullTextureName: template_small
+    slotFlags: BACK
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 3,0
+    strippingWindowPos: 0,5
+    displayName: Back
 # End Coyote
 
 - type: inventoryTemplate
@@ -38,6 +47,15 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+  - name: back
+    slotTexture: back
+    fullTextureName: template_small
+    slotFlags: BACK
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 3,0
+    strippingWindowPos: 0,5
+    displayName: Back
 # End Coyote
 
 - type: inventoryTemplate
@@ -59,6 +77,15 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+  - name: back
+    slotTexture: back
+    fullTextureName: template_small
+    slotFlags: BACK
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 3,0
+    strippingWindowPos: 0,5
+    displayName: Back
 # End Coyote
 
 # taller than tall
@@ -81,4 +108,13 @@
     uiWindowPos: 2,1
     strippingWindowPos: 2,4
     displayName: ID
+  - name: back
+    slotTexture: back
+    fullTextureName: template_small
+    slotFlags: BACK
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 3,0
+    strippingWindowPos: 0,5
+    displayName: Back
 # End Coyote


### PR DESCRIPTION
## About the PR
Give Borgs a backpack slot, the backpack isn't visible on their body but can be interacted with/removed like you would with any normal players backpack.

## Why / Balance
Borgs only have a single usable hand slot, and while toggling between the tools/modules is useful, when trying to do something there isn't a module for, you're stuck dragging a crate or throwing resources across the room.
Adding a backpack gives Borgs some generic storage they can use alongside their modules.

## Technical details
Copied the "back" inventory slot from the human template into the borg templates.
Added a check in the ClientClothingSystem to not draw the backpack on their body, as the backpacks don't sit in the correct place.

## How to test
 - Spawn as Borg
 - Put on backpack

## Media
<img width="637" height="847" alt="image" src="https://github.com/user-attachments/assets/53f17704-ef42-4bea-ab7f-95eceb82faa3" />

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- tweak: Borgs can now wear backpacks, they are however not shown on the chassis.
