### PR TITLE
Fix Un-anchored Pipe at St. Michaels

### DIFF
--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -6670,15 +6670,17 @@ entities:
   - uid: 798
     components:
     - type: Transform
-      anchored: False
+# Coyote: Fix un-anchored pipe for cryo
+#      anchored: False
       rot: 3.141592653589793 rad
       pos: 9.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-    - type: Physics
-      canCollide: True
-      bodyType: Dynamic
+#    - type: Physics
+#      canCollide: True
+#      bodyType: Dynamic
+# End Coyote
   - uid: 799
     components:
     - type: Transform

--- a/Resources/Maps/_NF/POI/medical.yml
+++ b/Resources/Maps/_NF/POI/medical.yml
@@ -6670,17 +6670,11 @@ entities:
   - uid: 798
     components:
     - type: Transform
-# Coyote: Fix un-anchored pipe for cryo
-#      anchored: False
       rot: 3.141592653589793 rad
       pos: 9.5,2.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0055CCFF'
-#    - type: Physics
-#      canCollide: True
-#      bodyType: Dynamic
-# End Coyote
   - uid: 799
     components:
     - type: Transform


### PR DESCRIPTION
## About the PR
Anchored the gas pipe in the Cryo room on St. Michaels

## Why / Balance
The pipe is un-anchored on round start, meaning the Cryo setup doesn't work by default, currently medical staff have to re-anchor it at the start of every shift.

## Technical details
Removed the un-anchored tag and physics component from the GasPipeBend, uid 798 on St.Michaels

## How to test
 - Load into St. Michaels
 - Go to Cryo room
 - Check if Cryo Pod has atmos

## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- fix: Fixed un-anchored pipe in Cryo on St. Michaels