### PR TITLE
Allow Subtle and Emotes while sleeping

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -337,7 +337,9 @@ public sealed partial class SleepingSystem : EntitySystem
     /// </summary>
     public void OnEmoteAttempt(Entity<SleepingComponent> ent, ref EmoteAttemptEvent args)
     {
-        args.Cancel();
+        // Coyote: Allow Emotes while sleeping
+        //args.Cancel();
+        // End Coyote
     }
 
     private void OnChangeForceSay(Entity<SleepingComponent> ent, ref BeforeForceSayEvent args)


### PR DESCRIPTION
## About the PR
Removed the restriction from sending Emotes (and subtle) while asleep.

## Why / Balance
Suggested in the Discord, I think you can guess why people want it.

## Technical details
Weirdly, this is a single-line change in SleepingSystem to bypass the OnEmoteAttempt restriction.
Subtle text is actually checking the CanEmote function rather than CanSpeak, so it's all covered by that one listener.

## How to test
 - Get into a bed, sleep
 - Try to send emotes or subtle messages, they should now work.
 - Try to send a regular message, it shouldn't go through.

## Media
<img width="988" height="502" alt="image" src="https://github.com/user-attachments/assets/8b2e2644-9e86-4322-8aea-45678ec6a40d" />


## Requirements
- [X] I have read [CONTRIBUTING.md](https://github.com/ARF-SS13/coyote-frontier/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

**Changelog**
:cl:
- tweak: Allowed Emotes and Subtle messages while sleeping.
